### PR TITLE
Generic Method for Coercing Values

### DIFF
--- a/atom/scalars.py
+++ b/atom/scalars.py
@@ -6,7 +6,6 @@
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
 from .catom import Member, DefaultValue, Validate, SetAttr
-from .coerced import Coerced
 
 
 class Value(Member):


### PR DESCRIPTION
This uses the pattern from `Array` in #17, allowing us to provide `Coercion` behavior to any value by passing `strict = False` without writing a new C++ handler for each Value type.  This could even be made a public member, allowing savvy users to add coercion behavior to custom Value classes.  I included an example for `Bool`.

``` python
from atom.api import Atom, Bool

class Test(Atom):
    b1 = Bool(0, strict=False)
    b2 = Bool(1, strict=False)

t = Test()
assert not t.b1
assert t.b2
```
