### PR TITLE
Enforce Member Behavior in Metaclass

### DIFF
--- a/atom/atom.py
+++ b/atom/atom.py
@@ -289,15 +289,18 @@ class AtomMeta(type):
                     members[key] = value
             # handle common errors in Atom definitions
             elif isinstance(value, AtomMeta):
+                # member = Subclass
                 msg = 'In class "{0}": member declaration "{1} = {2}"'
                 msg += ' not allowed, use "Instance({2})" or "Typed({2})"'
                 raise TypeError(msg.format(cls.__name__, key, value.__name__))
             elif isinstance(value, CAtom):
+                # member = Subclass()
                 msg = 'In class "{0}": member declaration "{1} = {2}()"'
                 msg += 'not allowed, use "Instance({2})" or "Typed({2})"'
                 raise TypeError(msg.format(cls.__name__, key, 
                                            value.__class__.__name__))
             elif not value == AtomMeta and hasattr(value, 'mro'):
+                # member = Bool
                 if Member in value.mro():
                     msg = 'In class "{0}": Atom Members must be '
                     msg += 'instantiated: "{1} = {2}" should be "{1} = {2}()"'


### PR DESCRIPTION
I noticed I had made three logical errors when trying Atom (I should have remembered the second from Traits).
- Not instantiating a Member

``` python
class Test(Atom):
    b = Bool
```
- Using sub-Atoms without them being Instance() or Type()

``` python
class Sub(Atom):
    pass

class Main(Atom):
    sub = Sub()
```
- Not instantiating sub-Atoms (needed to be handled separately).

``` python
class Sub(Atom):
    pass

class Main(Atom):
    sub = Sub
```
