### PR TITLE
Add Alias Class for Delegating Setting/Getting to other Atom objects

### DIFF
--- a/atom/alias.py
+++ b/atom/alias.py
@@ -1,0 +1,31 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2013, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#------------------------------------------------------------------------------
+from .catom import Member, DefaultValue, Validate
+
+
+class Alias(object):
+    """A descriptor that forbids negative values"""
+    
+    __slots__ = ()
+    
+    def __init__(self, default):
+        self.default = default
+        
+    def __get__(self, instance, owner):
+        # we get here when someone calls x.d, and d is a NonNegative instance
+        # instance = x
+        # owner = type(x)
+        return self.data.get(instance, self.default)
+    
+    def __set__(self, instance, value):
+        # we get here when someone calls x.d = val, and d is a NonNegative instance
+        # instance = x
+        # value = val
+        if value < 0:
+            raise ValueError("Negative value not allowed: %s" % value)
+        self.data[instance] = value

--- a/atom/alias.py
+++ b/atom/alias.py
@@ -5,27 +5,35 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from .catom import Member, DefaultValue, Validate
 
 
 class Alias(object):
-    """A descriptor that forbids negative values"""
+    """ An Atom attribute whose value is Aliased to another Atom Instance
+
+    The value is read from the other member and written to the other
+    member.
     
-    __slots__ = ()
+    """
+    __slots__ = ('other', 'alias_name', 'attr_name')
     
-    def __init__(self, default):
-        self.default = default
+    def __init__(self, other, alias_name=None):
+        # other starts out as a reference to the other object
+        self.other = other
+        self.alias_name = alias_name
+        self.attr_name = None
         
     def __get__(self, instance, owner):
-        # we get here when someone calls x.d, and d is a NonNegative instance
-        # instance = x
-        # owner = type(x)
-        return self.data.get(instance, self.default)
+        attr = self.alias_name or self.attr_name
+        # throw out our reference to the other Atom and just use its name
+        if not isinstance(self.other, str):
+            self.other = self.other.name
+        obj = getattr(instance, self.other)
+        return getattr(obj, attr)
     
     def __set__(self, instance, value):
-        # we get here when someone calls x.d = val, and d is a NonNegative instance
-        # instance = x
-        # value = val
-        if value < 0:
-            raise ValueError("Negative value not allowed: %s" % value)
-        self.data[instance] = value
+        attr = self.alias_name or self.attr_name
+        # throw out our reference to the other Atom and just use its name
+        if not isinstance(self.other, str):
+            self.other = self.other.name
+        obj = getattr(instance, self.other)
+        setattr(obj, attr, value)

--- a/atom/api.py
+++ b/atom/api.py
@@ -10,6 +10,7 @@ from .catom import (
     CAtom, Member, GetAttr, SetAttr, PostGetAttr, PostSetAttr,
     DefaultValue, Validate, PostValidate, atomref, atomlist, atomclist
 )
+from .alias import Alias
 from .coerced import Coerced
 from .containerlist import ContainerList
 from .delegator import Delegator


### PR DESCRIPTION
Implements #11 using the descriptor protocol.  I needed to add a hook in AtomMeta to set the `attr_name` of the alias, since I could not get it at instantiation time.

``` python
from atom.api import Atom, Instance, Unicode, Alias


class Company(Atom):

    address = Unicode('101 Main')


class Employee(Atom):

    name = Unicode()

    employer = Instance(Company, ())

    work_address = Alias(employer, 'address')


bob = Employee(name='Bob Smith')
assert bob.work_address == '101 Main'
bob.work_address = '23 Pine'
assert bob.employer.address == '23 Pine'
```
