### PR TITLE
Allow unicode as first argument of observe.

### DIFF
--- a/atom/property.py
+++ b/atom/property.py
@@ -83,7 +83,7 @@ class Property(Member):
 
         """
         self.fset = func
-        self.set_setattr_mode(SetAttr.CallObject_ObjectValue, func)
+        self.set_setattr_mode(GetAttr.CallObject_ObjectValue, func)
         return self
 
     def clone(self):


### PR DESCRIPTION
I just changed a check in CAtom_observe so that str and unicode behaves the same. A basic test works but I might have missed things. I am not sure how pertinent this truly is but as in most example Unicode is used instead of Str, if one tries to specify the first argument to observe as an attribute, things fail silently which can lead to pretty hard things to debug.
