### PR TITLE
Fix multiple references issue

### DIFF
--- a/atom/atom.py
+++ b/atom/atom.py
@@ -278,6 +278,7 @@ class AtomMeta(type):
             if isinstance(value, Member):
                 if value in owned_members:  # foo = bar = Baz()
                     value = value.clone()
+                    setattr(cls, key, value)
                 owned_members.add(value)
                 value.set_name(key)
                 if key in members:


### PR DESCRIPTION
Fix the behavior of the built-in setattr and getattr for "a = b = Float(...)" by updating the class dictionary so that the name refers to the new cloned member and not to the old one. Fix Issue #53
