### PR TITLE
Fix #29 Add message filtering to observers

### DIFF
--- a/atom/api.py
+++ b/atom/api.py
@@ -5,7 +5,7 @@
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #------------------------------------------------------------------------------
-from .atom import AtomMeta, Atom, observe, set_default
+from .atom import AtomMeta, Atom, observe, set_default, filter_on
 from .catom import (
     CAtom, Member, GetAttr, SetAttr, PostGetAttr, PostSetAttr,
     DefaultValue, Validate, PostValidate, atomref, atomlist, atomclist


### PR DESCRIPTION
Adds the ability to filter `@observe` functions with their change type as well as new-value validation functions.

`@filter_on('create', lambda x: len(x) == 5)` would call the function when the change status is `create` and the new value is five characters long.