### PR TITLE
Fix PyTypeObject instantiations on python 3.5

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -466,7 +466,11 @@ PyTypeObject Atom::TypeObject = {
 	( getattrfunc )0,                    /* tp_getattr */
 	( setattrfunc )0,                    /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                          /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                /* tp_as_async */
+#else
+	( void* ) 0,                         /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                        /* tp_compare */
 #endif

--- a/src/member.cpp
+++ b/src/member.cpp
@@ -1095,7 +1095,11 @@ PyTypeObject Member::TypeObject = {
 	( getattrfunc )0,                      /* tp_getattr */
 	( setattrfunc )0,                      /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                            /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                  /* tp_as_async */
+#else
+	( void* ) 0,                           /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                          /* tp_compare */
 #endif

--- a/src/memberchange.cpp
+++ b/src/memberchange.cpp
@@ -114,7 +114,11 @@ PyTypeObject MemberChange::TypeObject = {
 	( getattrfunc )0,                            /* tp_getattr */
 	( setattrfunc )0,                            /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                                  /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                        /* tp_as_async */
+#else
+	( void* ) 0,                                 /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                                /* tp_compare */
 #endif

--- a/src/methodwrapper.cpp
+++ b/src/methodwrapper.cpp
@@ -128,7 +128,11 @@ PyTypeObject MethodWrapper::TypeObject = {
 	( getattrfunc )0,                             /* tp_getattr */
 	( setattrfunc )0,                             /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                                   /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                         /* tp_as_async */
+#else
+	( void* ) 0,                                  /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                                 /* tp_compare */
 #endif

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -196,7 +196,11 @@ PyTypeObject Signal::TypeObject = {
 	( getattrfunc )0,                         /* tp_getattr */
 	( setattrfunc )0,                         /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                               /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                     /* tp_as_async */
+#else
+	( void* ) 0,                              /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                             /* tp_compare */
 #endif
@@ -250,7 +254,11 @@ PyTypeObject BoundSignal::TypeObject = {
 	( getattrfunc )0,                           /* tp_getattr */
 	( setattrfunc )0,                           /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                                 /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                       /* tp_as_async */
+#else
+	( void* ) 0,                                /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                               /* tp_compare */
 #endif

--- a/src/typeddict.cpp
+++ b/src/typeddict.cpp
@@ -335,7 +335,11 @@ PyTypeObject TypedDict::TypeObject = {
 	( getattrfunc )0,                           /* tp_getattr */
 	( setattrfunc )0,                           /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                                 /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                       /* tp_as_async */
+#else
+	( void* ) 0,                                /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                               /* tp_compare */
 #endif

--- a/src/typedlist.cpp
+++ b/src/typedlist.cpp
@@ -376,7 +376,11 @@ PyTypeObject TypedList::TypeObject = {
 	( getattrfunc )0,                             /* tp_getattr */
 	( setattrfunc )0,                             /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                                   /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                         /* tp_as_async */
+#else
+	( void* ) 0,                                  /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                                 /* tp_compare */
 #endif

--- a/src/typedset.cpp
+++ b/src/typedset.cpp
@@ -413,7 +413,11 @@ PyTypeObject TypedSet::TypeObject = {
 	( getattrfunc )0,                         /* tp_getattr */
 	( setattrfunc )0,                         /* tp_setattr */
 #ifdef IS_PY3K
-	( void* )0,                               /* tp_reserved */
+#if PY_MINOR_VERSION > 4
+	( PyAsyncMethods* )0,                     /* tp_as_async */
+#else
+	( void* ) 0,                              /* tp_reserved */
+#endif
 #else
 	( cmpfunc )0,                             /* tp_compare */
 #endif


### PR DESCRIPTION
The field definitions of `PyTypeObject` have changed in python 3.5. This adds the necessary `#if/else` statements to populate the object fields appropriately.