### PR TITLE
Prevent observer from propagating exceptions

### DIFF
--- a/atom/src/member.cpp
+++ b/atom/src/member.cpp
@@ -1077,7 +1077,9 @@ Member::notify( CAtom* atom, PyObject* args, PyObject* kwargs )
                 callable = *it;
             }
             if( !callable( argsptr, kwargsptr ) )
-                return false;
+            {
+                PyErr_Print();
+            }
         }
     }
     return true;

--- a/atom/src/modifyguard.h
+++ b/atom/src/modifyguard.h
@@ -30,16 +30,6 @@ public:
 
     ~ModifyGuard()
     {
-        // If an exception occurred we store it and restore it after the
-        // modification have been done as otherwise it can (Python 3) cause
-        // boolean tests (PyObject_IsTrue) to fail for wrong reasons.
-        bool exception_set = false;
-        PyObject *type, *value, *traceback;
-        if( PyErr_Occurred() ){
-            PyErr_Fetch(&type, &value, &traceback);
-            exception_set = true;
-        }
-
         if( m_owner.get_modify_guard() == this )
         {
             m_owner.set_modify_guard( 0 );
@@ -51,10 +41,6 @@ public:
                 delete *it;
             }
         }
-
-        // Restore previous exception if one was set.
-        if( exception_set )
-            PyErr_Restore(type, value, traceback);
     }
 
     void add_task( ModifyTask* task ) { m_tasks.push_back( task ); }

--- a/atom/src/observerpool.cpp
+++ b/atom/src/observerpool.cpp
@@ -7,7 +7,6 @@
 |----------------------------------------------------------------------------*/
 #include "observerpool.h"
 
-
 namespace
 {
 
@@ -220,7 +219,13 @@ ObserverPool::notify( PyObjectPtr& topic, PyObjectPtr& args, PyObjectPtr& kwargs
                 if( obs_it->is_true() )
                 {
                     if( !obs_it->operator()( args, kwargs ) )
-                        return false;
+                    {
+                        PyErr_Print();
+                        if( PyErr_Occurred() )
+                        {
+                            PyErr_Print();
+                        }
+                    }
                 }
                 else
                 {

--- a/atom/src/utils.h
+++ b/atom/src/utils.h
@@ -19,7 +19,6 @@ namespace utils
     #define STR_CHECK_EXACT( obj ) PyString_CheckExact( obj ) || PyUnicode_CheckExact( obj )
 #endif
 
-
 inline bool
 basestring_check( PyObject* obj )
 {


### PR DESCRIPTION
Following phosphor logic, observers should be well behaved and never raise. If they do the exceptions are simply printed to stderr.

This avoid the old SystemError bug.