### PR TITLE
sortedmap: Python 3 fix

### DIFF
--- a/atom/src/pythonhelpers.h
+++ b/atom/src/pythonhelpers.h
@@ -295,15 +295,10 @@ public:
             if( clear_err )
                 PyErr_Clear();
 
-            // FIXME: compare pointers in case of comparison problems
             switch (opid)
             {
-            case Py_LT: return m_pyobj < other;
-            case Py_LE: return m_pyobj <= other;
             case Py_EQ: return m_pyobj == other;
             case Py_NE: return m_pyobj != other;
-            case Py_GT: return m_pyobj > other;
-            case Py_GE: return m_pyobj >= other;
             }
         }
         return false;

--- a/atom/src/sortedmap.cpp
+++ b/atom/src/sortedmap.cpp
@@ -14,32 +14,6 @@
 
 using namespace PythonHelpers;
 
-bool compare_less( PyObject* first, PyObject* second )
-{
-    int r = PyObject_RichCompareBool( first, second, Py_LT );
-    if( r == 1 )
-        return true;
-    if( r == 0 )
-        return false;
-
-    if ( PyErr_Occurred() )
-    {
-        PyErr_Clear();
-        PyObjectPtr f_type_name( PyObject_GetAttrString ( pyobject_cast( first->ob_type ),  "__name__" ) );
-        PyObjectPtr s_type_name( PyObject_GetAttrString ( pyobject_cast( second->ob_type ),  "__name__" ) );
-        if( f_type_name.richcompare( s_type_name, Py_EQ ) )
-        {
-            return first < second;
-
-        }
-        else
-        {
-            return f_type_name.richcompare( s_type_name, Py_LT );
-        }
-    }
-    return false;
-}
-
 class MapItem
 {
 
@@ -84,21 +58,22 @@ public:
         {
             if( first.m_key == second.m_key )
                 return false;
-            return compare_less( first.m_key.get(), second.m_key.get() );
+            return first.m_key.richcompare( second.m_key, Py_LT );
         }
 
         bool operator()( MapItem& first, PyObject* second )
         {
             if( first.m_key == second )
                 return false;
-            return compare_less( first.m_key.get(), second );
+            return first.m_key.richcompare( second, Py_LT );
         }
 
         bool operator()( PyObject* first, MapItem& second )
         {
             if( first == second.m_key )
                 return false;
-            return compare_less( first, second.m_key.get() );
+            PyObjectPtr temp( newref( first ) );
+            return temp.richcompare( second.m_key, Py_LT );
         }
     };
 

--- a/atom/src/sortedmap.cpp
+++ b/atom/src/sortedmap.cpp
@@ -14,6 +14,32 @@
 
 using namespace PythonHelpers;
 
+bool compare_less( PyObject* first, PyObject* second )
+{
+    int r = PyObject_RichCompareBool( first, second, Py_LT );
+    if( r == 1 )
+        return true;
+    if( r == 0 )
+        return false;
+
+    if ( PyErr_Occurred() )
+    {
+        PyErr_Clear();
+        PyObjectPtr f_type_name( PyObject_GetAttrString ( pyobject_cast( first->ob_type ),  "__name__" ) );
+        PyObjectPtr s_type_name( PyObject_GetAttrString ( pyobject_cast( second->ob_type ),  "__name__" ) );
+        if( f_type_name.richcompare( s_type_name, Py_EQ ) )
+        {
+            return first < second;
+
+        }
+        else
+        {
+            return f_type_name.richcompare( s_type_name, Py_LT );
+        }
+    }
+    return false;
+}
+
 class MapItem
 {
 
@@ -58,22 +84,21 @@ public:
         {
             if( first.m_key == second.m_key )
                 return false;
-            return first.m_key.richcompare( second.m_key, Py_LT );
+            return compare_less( first.m_key.get(), second.m_key.get() );
         }
 
         bool operator()( MapItem& first, PyObject* second )
         {
             if( first.m_key == second )
                 return false;
-            return first.m_key.richcompare( second, Py_LT );
+            return compare_less( first.m_key.get(), second );
         }
 
         bool operator()( PyObject* first, MapItem& second )
         {
             if( first == second.m_key )
                 return false;
-            PyObjectPtr temp( newref( first ) );
-            return temp.richcompare( second.m_key, Py_LT );
+            return compare_less( first, second.m_key.get() );
         }
     };
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,0 @@
-#------------------------------------------------------------------------------
-# Copyright (c) 2013, Nucleic Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#------------------------------------------------------------------------------


### PR DESCRIPTION
Allow to sort any object under Python 3 by sorting by class name and pointer value, which emulates the old behavior on Python 2 more or less.

I have also removed the fallback for sorting object based on direct pointer comparison as it does not make sense from my point of view. I left it for EQ and NE. This does not impact Atom codebase since only Py_EQ was used outside of sortedmap.

I am unsure about the safeguards that should protect the name comparison. It seems to me that an object should always have a type and its type a name but I am opened to suggestions.