### PR TITLE
This fixes the `richcompare` method on Python 3

### DIFF
--- a/atom/src/pythonhelpers.h
+++ b/atom/src/pythonhelpers.h
@@ -147,8 +147,8 @@ inline int
 fallback_3way_compare( PyObject* first, PyObject* second ) {
     // Compare pointer values if the types are the same.
     if( first->ob_type == second->ob_type ) {
-        Py_uintptr_t fp = static_cast<Py_uintptr_t>( first );
-        Py_uintptr_t sp = static_cast<Py_uintptr_t>( second );
+        Py_uintptr_t fp = reinterpret_cast<Py_uintptr_t>( first );
+        Py_uintptr_t sp = reinterpret_cast<Py_uintptr_t>( second );
         return (fp < sp) ? -1 : (fp > sp) ? 1 : 0;
     }
 
@@ -168,8 +168,8 @@ fallback_3way_compare( PyObject* first, PyObject* second ) {
         return 1;
 
     // Finally, fall back to comparing type pointers.
-    Py_uintptr_t ftp = static_cast<Py_uintptr_t>( first->ob_type );
-    Py_uintptr_t stp = static_cast<Py_uintptr_t>( second->ob_type );
+    Py_uintptr_t ftp = reinterpret_cast<Py_uintptr_t>( first->ob_type );
+    Py_uintptr_t stp = reinterpret_cast<Py_uintptr_t>( second->ob_type );
     return ftp < stp ? -1 : 1;
 }
 


### PR DESCRIPTION
Closes #76

cc @MatthieuDartiailh