### PR TITLE
FIX: proper size check for list creation

### DIFF
--- a/atom/src/atomlist.cpp
+++ b/atom/src/atomlist.cpp
@@ -89,7 +89,7 @@ ListSubtype_New( PyTypeObject* subtype, Py_ssize_t size )
 {
     if( size < 0 )
         return py_bad_internal_call( "negative list size" );
-    if( static_cast<size_t>( size ) > PY_SIZE_MAX / sizeof( PyObject* ) )
+    if( static_cast<size_t>( size ) > PY_SSIZE_T_MAX / sizeof( PyObject* ) )
         return PyErr_NoMemory();
     PyObjectPtr ptr( PyType_GenericNew( subtype, 0, 0 ) );
     if( !ptr )


### PR DESCRIPTION
During installation of the package on Debian (within [Docker](https://hub.docker.com/r/nsls2/debian-with-miniconda/)) with Python 3.6 (conda), the following error appears:
```py
$ python setup.py install
running install
running bdist_egg
running egg_info
writing atom.egg-info/PKG-INFO
writing dependency_links to atom.egg-info/dependency_links.txt
writing requirements to atom.egg-info/requires.txt
writing top-level names to atom.egg-info/top_level.txt
reading manifest file 'atom.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching '*.md'
warning: no files found matching '*.rst' under directory 'docs'
warning: no files found matching '*.png' under directory 'docs'
warning: no files found matching '*.py' under directory 'docs'
warning: no files found matching '*.txt' under directory 'licenses'
no previously-included directories found matching '.git'
no previously-included directories found matching 'docs/build'
no previously-included directories found matching 'dist'
no previously-included directories found matching 'build'
writing manifest file 'atom.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
running build_ext
building 'atom.catom' extension
gcc -pthread -B /conda/envs/py36/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/conda/envs/py36/include/python3.6m -c atom/src/atomlist.cpp -o build/temp.linux-x86_64-3.6/atom/src/atomlist.o
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
atom/src/atomlist.cpp: In function ‘PyObject* ListSubtype_New(PyTypeObject*, Py_ssize_t)’:
atom/src/atomlist.cpp:92:39: error: ‘SIZE_MAX’ was not declared in this scope
error: command 'gcc' failed with exit status 1
```
The PR is intended to fix the problem.

A note: we are building conda packages in our channel https://anaconda.org/lightsource2-tag, and noticed this error.