### PR TITLE
Fix py27 build when using clang

### DIFF
--- a/atom/src/pythonhelpers.h
+++ b/atom/src/pythonhelpers.h
@@ -17,10 +17,6 @@
     return Py_INCREF(Py_NotImplemented), Py_NotImplemented
 #endif
 
-#ifndef cmpfunc
-#define cmpfunc int
-#endif
-
 
 #define pyobject_cast( o ) ( reinterpret_cast<PyObject*>( o ) )
 #define pytype_cast( o ) ( reinterpret_cast<PyTypeObject*>( o ) )


### PR DESCRIPTION
Not sure why that's there in the first place?