### PR TITLE
Make all comparisons used in C safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -55,7 +55,6 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
           fail_ci_if_error: true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -64,5 +63,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           name: codecov-umbrella
-          yml: ./codecov.yml
           fail_ci_if_error: true

--- a/atom/src/member.cpp
+++ b/atom/src/member.cpp
@@ -967,7 +967,7 @@ Member::add_observer( PyObject* observer )
     std::vector<cppy::ptr>::iterator end = static_observers->end();
     for( it = static_observers->begin(); it != end; ++it )
     {
-        if( *it == obptr || it->richcmp( obptr, Py_EQ ) )
+        if( *it == obptr || utils::safe_richcompare( it->get(), obptr, Py_EQ ) )
             return;
     }
     static_observers->push_back( obptr );
@@ -991,7 +991,7 @@ Member::remove_observer( PyObject* observer )
         std::vector<cppy::ptr>::iterator end = static_observers->end();
         for( it = static_observers->begin(); it != end; ++it )
         {
-            if( *it == obptr || it->richcmp( obptr, Py_EQ ) )
+            if( *it == obptr || utils::safe_richcompare( it->get(), obptr, Py_EQ ) )
             {
                 static_observers->erase( it );
                 if( static_observers->size() == 0 )
@@ -1016,7 +1016,7 @@ Member::has_observer( PyObject* observer )
     std::vector<cppy::ptr>::iterator end = static_observers->end();
     for( it = static_observers->begin(); it != end; ++it )
     {
-        if( *it == obptr || it->richcmp( obptr, Py_EQ ) )
+        if( *it == obptr || utils::safe_richcompare( it->get(), obptr, Py_EQ ) )
             return true;
     }
     return false;

--- a/atom/src/observerpool.cpp
+++ b/atom/src/observerpool.cpp
@@ -6,6 +6,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 #include "observerpool.h"
+#include "utils.h"
 
 
 namespace atom
@@ -82,7 +83,7 @@ ObserverPool::has_observer( cppy::ptr& topic, cppy::ptr& observer )
             obs_end = obs_it + topic_it->m_count;
             for( ; obs_it != obs_end; ++obs_it )
             {
-                if( *obs_it == observer || obs_it->richcmp( observer, Py_EQ ) )
+                if( *obs_it == observer || utils::safe_richcompare( obs_it->get(), observer, Py_EQ ) )
                     return true;
             }
             return false;
@@ -117,7 +118,7 @@ ObserverPool::add( cppy::ptr& topic, cppy::ptr& observer )
             obs_free = obs_end;
             for( ; obs_it != obs_end; ++obs_it )
             {
-                if( *obs_it == observer || obs_it->richcmp( observer, Py_EQ ) )
+                if( *obs_it == observer || utils::safe_richcompare( obs_it->get(), observer, Py_EQ ) )
                     return;
                 if( !obs_it->is_truthy() )
                     obs_free = obs_it;
@@ -160,7 +161,7 @@ ObserverPool::remove( cppy::ptr& topic, cppy::ptr& observer )
             obs_end = obs_it + topic_it->m_count;
             for( ; obs_it != obs_end; ++obs_it )
             {
-                if( *obs_it == observer || obs_it->richcmp( observer, Py_EQ ) )
+                if( *obs_it == observer || utils::safe_richcompare( obs_it->get(), observer, Py_EQ ) )
                 {
                     m_observers.erase( obs_it );
                     if( ( --topic_it->m_count ) == 0 )

--- a/atom/src/observerpool.h
+++ b/atom/src/observerpool.h
@@ -11,6 +11,8 @@
 #include <cppy/cppy.h>
 #include "platstdint.h"
 #include "modifyguard.h"
+#include "utils.h"
+
 
 namespace atom
 {
@@ -26,7 +28,7 @@ class ObserverPool
         ~Topic() {}
         bool match( cppy::ptr& topic )
         {
-            return m_topic == topic || m_topic.richcmp( topic, Py_EQ );
+            return m_topic == topic || utils::safe_richcompare( m_topic, topic, Py_EQ );
         }
         cppy::ptr m_topic;
         uint32_t m_count;

--- a/atom/src/propertyhelper.cpp
+++ b/atom/src/propertyhelper.cpp
@@ -10,6 +10,7 @@
 #include "catom.h"
 #include "member.h"
 #include "memberchange.h"
+#include "utils.h"
 
 
 namespace atom
@@ -80,7 +81,7 @@ reset_property( PyObject* mod, PyObject* args )
             return 0;
         }
         bool cached = member->get_getattr_mode() == GetAttr::CachedProperty;
-        if( !cached || !oldptr.richcmp( newptr, Py_EQ ) )
+        if( !cached || !utils::safe_richcompare( oldptr, newptr, Py_EQ ) )
         {
             cppy::ptr argsptr( property_args( atom, member, oldptr.get(), newptr.get() ) );
             if( !argsptr )

--- a/atom/src/setattrbehavior.cpp
+++ b/atom/src/setattrbehavior.cpp
@@ -8,6 +8,7 @@
 #include <cppy/cppy.h>
 #include "member.h"
 #include "memberchange.h"
+#include "utils.h"
 
 
 namespace atom
@@ -130,7 +131,7 @@ slot_handler( Member* member, CAtom* atom, PyObject* value )
         cppy::ptr argsptr;
         if( member->has_observers() )
         {
-            if( valid_old && oldptr.richcmp( newptr, Py_EQ ) )
+            if( valid_old && utils::safe_richcompare( oldptr, newptr, Py_EQ ) )
                 return 0;
             if( valid_old )
                 argsptr = updated_args( atom, member, oldptr.get(), newptr.get() );
@@ -145,7 +146,7 @@ slot_handler( Member* member, CAtom* atom, PyObject* value )
         {
             if( !argsptr )
             {
-                if( valid_old && oldptr.richcmp( newptr, Py_EQ ) )
+                if( valid_old && utils::safe_richcompare( oldptr, newptr, Py_EQ ) )
                     return 0;
                 if( valid_old )
                     argsptr = updated_args( atom, member, oldptr.get(), newptr.get() );

--- a/atom/src/sortedmap.cpp
+++ b/atom/src/sortedmap.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <sstream>
 #include "packagenaming.h"
+#include "utils.h"
 
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wdeprecated-writable-strings"
@@ -23,80 +24,6 @@
 
 namespace
 {
-
-/**
- * A fallback 3way comparison function for when PyObject_RichCompareBool
- * fails to compare "unorderable types" on Python 3.
- *
- * This is based on Python 2's `default_3way_compare`.
- *
- * This function will not change the Python exception state.
- */
-inline int
-fallback_3way_compare( PyObject* first, PyObject* second )
-{
-    // Compare pointer values if the types are the same.
-    if( first->ob_type == second->ob_type ) {
-        Py_uintptr_t fp = reinterpret_cast<Py_uintptr_t>( first );
-        Py_uintptr_t sp = reinterpret_cast<Py_uintptr_t>( second );
-        return (fp < sp) ? -1 : (fp > sp) ? 1 : 0;
-    }
-
-    // None is smaller than anything.
-    if( first == Py_None )
-        return -1;
-    if( second == Py_None )
-        return 1;
-
-    // Compare based on type names, numbers are smaller.
-    const char* fn = PyNumber_Check( first ) ? "" : first->ob_type->tp_name;
-    const char* sn = PyNumber_Check( second ) ? "" : second->ob_type->tp_name;
-    int c = strcmp( fn, sn );
-    if( c < 0 )
-        return -1;
-    if( c > 0 )
-        return 1;
-
-    // Finally, fall back to comparing type pointers.
-    Py_uintptr_t ftp = reinterpret_cast<Py_uintptr_t>( first->ob_type );
-    Py_uintptr_t stp = reinterpret_cast<Py_uintptr_t>( second->ob_type );
-    return ftp < stp ? -1 : 1;
-}
-
-
-bool richcompare( PyObject* first, PyObject* second, int opid )
-{
-    // Start with Python's rich compare.
-    int r = PyObject_RichCompareBool( first, second, opid );
-
-    // Handle a successful comparison.
-    if( r == 1 )
-        return true;
-    if( r == 0 )
-        return false;
-
-    // Clear the error if one happened because we attempted an invalid
-    // comparison.
-    if( PyErr_Occurred() )
-        PyErr_Clear();
-
-    // Fallback to the Python 2 default 3 way compare.
-    int c = fallback_3way_compare( first, second );
-
-    // Convert the 3way comparison result based on the `opid`.
-    switch (opid) {
-    case Py_EQ: return c == 0;
-    case Py_NE: return c != 0;
-    case Py_LE: return c <= 0;
-    case Py_GE: return c >= 0;
-    case Py_LT: return c < 0;
-    case Py_GT: return c > 0;
-    }
-
-    // Return `false` if the `opid` is not handled.
-    return false;
-}
-
 
 class MapItem
 {
@@ -142,21 +69,21 @@ public:
         {
             if( first.m_key == second.m_key )
                 return false;
-            return richcompare( first.m_key.get(), second.m_key.get(), Py_LT );
+            return atom::utils::safe_richcompare( first.m_key.get(), second.m_key.get(), Py_LT );
         }
 
         bool operator()( MapItem& first, PyObject* second )
         {
             if( first.m_key == second )
                 return false;
-            return richcompare( first.m_key.get(), second, Py_LT );
+            return atom::utils::safe_richcompare( first.m_key.get(), second, Py_LT );
         }
 
         bool operator()( PyObject* first, MapItem& second )
         {
             if( first == second.m_key )
                 return false;
-            return richcompare( first, second.m_key.get(), Py_LT );
+            return atom::utils::safe_richcompare( first, second.m_key.get(), Py_LT );
         }
     };
 
@@ -166,21 +93,21 @@ public:
         {
             if( first.m_key == second.m_key )
                 return true;
-            return richcompare( first.m_key.get(), second.m_key.get(), Py_EQ );
+            return atom::utils::safe_richcompare( first.m_key.get(), second.m_key.get(), Py_EQ );
         }
 
         bool operator()( MapItem& first, PyObject* second )
         {
             if( first.m_key == second )
                 return true;
-            return richcompare( first.m_key.get(),  second, Py_EQ );
+            return atom::utils::safe_richcompare( first.m_key.get(),  second, Py_EQ );
         }
 
         bool operator()( PyObject* first, MapItem& second )
         {
             if( first == second.m_key )
                 return true;
-            return richcompare( first, second.m_key.get(), Py_EQ );
+            return atom::utils::safe_richcompare( first, second.m_key.get(), Py_EQ );
         }
     };
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
   status:
     project: yes
     patch: yes
-    changes: no
+    changes: yes
 
 parsers:
   gcov:

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -1,6 +1,10 @@
 Atom Release Notes
 ==================
 
+0.5.2 - unreleased
+------------------
+- make comparison used in C safe (fix bug introduced in 0.5.0) PR #107
+
 0.5.1 - 03-06-2020
 ------------------
 - fix bug in using atomlist from C PR #102

--- a/tests/datastructure/test_sortedmap.py
+++ b/tests/datastructure/test_sortedmap.py
@@ -161,6 +161,27 @@ def test_ordering_with_inhomogeneous(smap):
     smap[1] = 4
     assert [k for k in smap.keys()] == [1, '0', 'a', 'b', 'c', 'd']
 
+    # Test ordering None, which is smaller than anything
+    s = sortedmap()
+    s[1] = 1
+    s[None] = 1
+    assert [k for k in s.keys()] == [None, 1]
+
+    s = sortedmap()
+    s[None] = 1
+    s[1] = 1
+    assert [k for k in s.keys()] == [None, 1]
+
+    # Test ordering classes that cannot be ordered through the usual mean
+    class T:
+        pass
+    t1 = T()
+    t2 = T()
+    s = sortedmap()
+    s[t1] = 1
+    s[t2] = 1
+    assert [k for k in s.keys()] == [t1, t2] if id(t1) < id(t2) else [t2, t1]
+
 
 def test_deleting_keys(smap):
     """Test deleting items.

--- a/tests/datastructure/test_sortedmap.py
+++ b/tests/datastructure/test_sortedmap.py
@@ -172,15 +172,20 @@ def test_ordering_with_inhomogeneous(smap):
     s[1] = 1
     assert [k for k in s.keys()] == [None, 1]
 
-    # Test ordering classes that cannot be ordered through the usual mean
+    # Test ordering class that cannot be ordered through the usual mean
     class T:
         pass
     t1 = T()
     t2 = T()
+    class U:
+        pass
+    u = U()
     s = sortedmap()
     s[t1] = 1
     s[t2] = 1
     assert [k for k in s.keys()] == [t1, t2] if id(t1) < id(t2) else [t2, t1]
+    s[u] = 1
+    assert [k for k in s.keys()][0] is u if id(U) < id(T) else [k for k in s.keys()][-1] is u
 
 
 def test_deleting_keys(smap):

--- a/tests/datastructure/test_sortedmap.py
+++ b/tests/datastructure/test_sortedmap.py
@@ -177,15 +177,16 @@ def test_ordering_with_inhomogeneous(smap):
         pass
     t1 = T()
     t2 = T()
-    class U:
+    oT = T
+    class T:
         pass
-    u = U()
+    u = T()
     s = sortedmap()
     s[t1] = 1
     s[t2] = 1
     assert [k for k in s.keys()] == [t1, t2] if id(t1) < id(t2) else [t2, t1]
     s[u] = 1
-    assert [k for k in s.keys()][0] is u if id(U) < id(T) else [k for k in s.keys()][-1] is u
+    assert [k for k in s.keys()][0] is u if id(T) < id(oT) else [k for k in s.keys()][-1] is u
 
 
 def test_deleting_keys(smap):

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -9,8 +9,8 @@
 
 """
 import pytest
-from atom.api import (Atom, Int, Property, GetAttr, SetAttr,
-                      observe, cached_property)
+from atom.api import (Atom, GetAttr, Int, Property, SetAttr, Value,
+                      cached_property, observe)
 from atom.catom import DelAttr, reset_property
 
 
@@ -167,9 +167,17 @@ def test_observed_property():
     """Test observing a property.
 
     """
+    class NonComparableObject:
+
+        def __eq__(self, other):
+            raise ValueError()
+
+        def __add__(self, other):
+            return other + 5
+
     class PropertyTest(Atom):
 
-        i = Int()
+        i = Value(0)
 
         counter = Int()
 
@@ -188,9 +196,11 @@ def test_observed_property():
     assert pt.prop == 1
     assert pt.prop == 2
 
+    pt.i = NonComparableObject()
     pt.observe('prop', pt.observe_cp)
     pt.get_member('prop').reset(pt)
     assert pt.counter == 2
+    assert pt.prop == 7
 
 
 def test_wrong_reset_arguments():


### PR DESCRIPTION
Fixes #105 

We now systematically clear errors occurring during comparison and fallback to 3 way comparison if an error occurred.

@frmdstryr please review the changes and confirm it fixes your issue (I already tested the reproducer from #105). 