### PR TITLE
Add strict to FloatRange

### DIFF
--- a/atom/scalars.py
+++ b/atom/scalars.py
@@ -108,10 +108,13 @@ class Int(Value):
 class FloatRange(Value):
     """ A float value clipped to a range.
 
+    By default, ints and longs will be promoted to floats. Pass
+    strict=True to the constructor to enable strict float checking.
+
     """
     __slots__ = ()
 
-    def __init__(self, low=None, high=None, value=None):
+    def __init__(self, low=None, high=None, value=None, strict=False):
         if low is not None and high is not None and low > high:
             low, high = high, low
         default = 0.0
@@ -122,7 +125,10 @@ class FloatRange(Value):
         elif high is not None:
             default = high
         super(FloatRange, self).__init__(default)
-        self.set_validate_mode(Validate.FloatRange, (low, high))
+        if strict:
+            self.set_validate_mode(Validate.FloatRange, (low, high))
+        else:
+            self.set_validate_mode(Validate.FloatRangePromote, (low, high))
 
 
 class Range(Value):

--- a/atom/src/behaviors.h
+++ b/atom/src/behaviors.h
@@ -143,6 +143,7 @@ enum Mode
     Enum,
     Callable,
     FloatRange,
+    FloatRangePromote,
     Range,
     Coerced,
     Delegate,

--- a/atom/src/enumtypes.cpp
+++ b/atom/src/enumtypes.cpp
@@ -280,6 +280,7 @@ bool init_enumtypes()
         add_long( dict_ptr, expand_enum( Enum ) );
         add_long( dict_ptr, expand_enum( Callable ) );
         add_long( dict_ptr, expand_enum( FloatRange ) );
+        add_long( dict_ptr, expand_enum( FloatRangePromote ) );
         add_long( dict_ptr, expand_enum( Range ) );
         add_long( dict_ptr, expand_enum( Coerced ) );
         add_long( dict_ptr, expand_enum( Delegate ) );

--- a/atom/src/validatebehavior.cpp
+++ b/atom/src/validatebehavior.cpp
@@ -702,16 +702,14 @@ PyObject*
 float_range_promote_handler( Member* member, CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
     if( PyFloat_Check( newvalue ) )
-        return float_range_handler(member, atom, oldvalue, newvalue);
+        return float_range_handler( member, atom, oldvalue, newvalue );
     if( PyLong_Check( newvalue ) )
     {
         double value = PyLong_AsDouble( newvalue );
         if( value == -1.0 && PyErr_Occurred() )
             return 0;
-        PyObject* convertedvalue = PyFloat_FromDouble( value );
-        PyObject* result = float_range_handler(member, atom, oldvalue, convertedvalue);
-        cppy::decref(convertedvalue);
-        return result;
+        cppy::ptr convertedvalue( PyFloat_FromDouble( value ) );
+        return float_range_handler( member, atom, oldvalue, convertedvalue.get() );
     }
     return validate_type_fail( member, atom, newvalue, "float" );
 }

--- a/atom/src/validatebehavior.cpp
+++ b/atom/src/validatebehavior.cpp
@@ -699,6 +699,25 @@ float_range_handler( Member* member, CAtom* atom, PyObject* oldvalue, PyObject* 
 
 
 PyObject*
+float_range_promote_handler( Member* member, CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
+{
+    if( PyFloat_Check( newvalue ) )
+        return float_range_handler(member, atom, oldvalue, newvalue);
+    if( PyLong_Check( newvalue ) )
+    {
+        double value = PyLong_AsDouble( newvalue );
+        if( value == -1.0 && PyErr_Occurred() )
+            return 0;
+        PyObject* convertedvalue = PyFloat_FromDouble( value );
+        PyObject* result = float_range_handler(member, atom, oldvalue, convertedvalue);
+        cppy::decref(convertedvalue);
+        return result;
+    }
+    return validate_type_fail( member, atom, newvalue, "float" );
+}
+
+
+PyObject*
 range_handler( Member* member, CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
     if( !PyLong_Check( newvalue ) )
@@ -833,6 +852,7 @@ handlers[] = {
     enum_handler,
     callable_handler,
     float_range_handler,
+    float_range_promote_handler,
     range_handler,
     coerced_handler,
     delegate_handler,

--- a/docs/source/basis/members.rst
+++ b/docs/source/basis/members.rst
@@ -125,8 +125,10 @@ Atom provides the following members for basic scalars types:
 - |Value|: a member that can receives any value, no validation is performed
 - |Int|: an integer value. One can choose if it is allowed to cast the assigned
   values (float to int), the default is true.
+- |Range|: an integer value that is clamped to fall within a range.
 - |Float|: a floating point value. One can choose if it is allowed to cast the
   assigned values (int to float, ...), the default is true.
+- |FloatRange|: a floating point value that is clamped to fall within a range.
 - |Bytes|, |Str|: bytes and unicode strings. One can choose if it is allowed to cast the
   assigned values (str to bytes, ...), the default is false.
 - |Enum|: a value that can only take a finite set of values. Note that this is

--- a/docs/source/substitutions.sub
+++ b/docs/source/substitutions.sub
@@ -29,7 +29,11 @@
 
 .. |Int| replace:: :py:class:`~atom.scalars.Int`
 
+.. |Range| replace:: :py:class:`~atom.scalars.Range`
+
 .. |Float| replace:: :py:class:`~atom.scalars.Float`
+
+.. |FloatRange| replace:: :py:class:`~atom.scalars.FloatRange`
 
 .. |Str| replace:: :py:class:`~atom.scalars.Str`
 

--- a/examples/api/range.py
+++ b/examples/api/range.py
@@ -20,6 +20,8 @@ class Experiment(Atom):
 
     gain = Range(0, 100, 10)
 
+    scale = FloatRange(0.0, 2.0, 1.0, strict=True)
+
 
 if __name__ == '__main__':
     exp = Experiment()
@@ -31,3 +33,11 @@ if __name__ == '__main__':
     print(exp.gain)
     exp.gain = 99
     print(exp.gain)
+
+    print(exp.scale)
+    try:
+        exp.scale = 2  # strict=False prevents assigning int/long
+    except TypeError as e:
+        print(e)
+        exp.scale = 2.0
+    print(exp.scale)

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -13,6 +13,7 @@ Atom Release Notes
   OptionalInstance, OptionalTyped and new Instance and Typed variant describing
   the validation behavior for the member with optional=False have been added.
 - consistently use Instance to wrap types passed to containers. PR #123
+- add strict argument to FloatRange. PR #124
 
 
 0.6.0 - 02/11/2020

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -79,6 +79,8 @@ def test_no_op_validation():
                           (FloatRange(0.0), [0.0, 0.6], [0.0, 0.6], [-0.1, '']),
                           (FloatRange(high=0.5), [-0.3, 0.5], [-0.3, 0.5],
                            [0.6]),
+                          (FloatRange(1.0, 10.0, strict=True), [1.0, 3.7],
+                           [1.0, 3.7], [2, 4, 0, -11]),
                           (Bytes(), [b'a', u'a'], [b'a']*2, [1]),
                           (Bytes(strict=True), [b'a'], [b'a'], [u'a']),
                           (Str(), [b'a', u'a'], ['a']*2, [1]),


### PR DESCRIPTION
I've been wanting a FloatRange with strict=False for a while but have just been using Float or manually casting.  

Also unsure if the input parameters be wrapped in float so ints can be passed?

Hopefully I did that right...