### PR TITLE
allow to validate the type of ReadOnly and Constant

### DIFF
--- a/atom/scalars.py
+++ b/atom/scalars.py
@@ -48,10 +48,12 @@ class ReadOnly(Value):
     """
     __slots__ = ()
 
-    def __init__(self, default=None, factory=None):
+    def __init__(self, kind=None, *, default=None, factory=None):
         super(ReadOnly, self).__init__(default, factory)
         self.set_setattr_mode(SetAttr.ReadOnly, None)
         self.set_delattr_mode(DelAttr.ReadOnly, None)
+        if kind:
+            self.set_validate_mode(Validate.Instance, kind)
 
 
 class Constant(Value):
@@ -60,10 +62,12 @@ class Constant(Value):
     """
     __slots__ = ()
 
-    def __init__(self, default=None, factory=None):
+    def __init__(self, default=None, *, factory=None, kind=None):
         super(Constant, self).__init__(default, factory)
         self.set_setattr_mode(SetAttr.Constant, None)
         self.set_delattr_mode(DelAttr.Constant, None)
+        if kind:
+            self.set_validate_mode(Validate.Instance, kind)
 
 
 class Callable(Value):

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -4,6 +4,11 @@ Atom Release Notes
 
 0.7.0 - unreleased
 ------------------
+- allow to specify the type of ReadOnly and Constant. PR #128
+  The validation is done using the Instance validator. The change for ReadOnly
+  is backward incompatible since the type or tuple of type is the first argument
+  in place of the default value. Specifying the default value by keyword is both
+  forward and backward compatible.
 - make the factory argument of Typed, Instance and their forwarded version
   keyword only. PR #123
 - add an optional keyword-only argument to Typed, Instance and their forwarded
@@ -11,7 +16,7 @@ Atom Release Notes
   a valid value. The default value is True. PR #123
 - the Instance and Typed variants of the Validate enum have been renamed to
   OptionalInstance, OptionalTyped and new Instance and Typed variant describing
-  the validation behavior for the member with optional=False have been added.
+  the validation behavior for the member with optional=False have been added. PR #123
 - consistently use Instance to wrap types passed to containers. PR #123
 - add strict argument to FloatRange. PR #124
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -41,12 +41,11 @@
 import sys
 
 import pytest
-
-from atom.api import (Atom, Bool, Bytes, Callable, CAtom, Coerced,
+from atom.api import (Atom, Bool, Bytes, Callable, CAtom, Coerced, Constant,
                       ContainerList, Delegator, Dict, Enum, Event, Float,
                       FloatRange, ForwardInstance, ForwardSubclass,
-                      ForwardTyped, Instance, Int, List, Range, Set, Str,
-                      Subclass, Tuple, Typed, Str, Validate, Value)
+                      ForwardTyped, Instance, Int, List, Range, ReadOnly, Set,
+                      Str, Subclass, Tuple, Typed, Validate, Value)
 
 
 def test_no_op_validation():
@@ -63,6 +62,7 @@ def test_no_op_validation():
 
 @pytest.mark.parametrize("member, set_values, values, raising_values",
                          [(Value(), ['a', 1, None], ['a', 1, None], []),
+                          (ReadOnly(int), [1], [1], [1.0]),
                           (Bool(), [True, False], [True, False], 'r'),
                           (Int(strict=True), [1], [1], [1.0]),
                           (Int(strict=False), [1, 1.0, int(1)], 3*[1], ['a']),
@@ -234,6 +234,25 @@ def test_event_validation():
         evt.ev_member = 1.0
     with pytest.raises(TypeError):
         evt.ev_type = 1.0
+
+
+def test_constant_validation():
+    """Test validating a constant."""
+
+    class A(Atom):
+        c = Constant(kind=int)
+
+        def _default_c(self):
+            return id(self)
+
+    A().c
+
+    class B(A):
+        def _default_c(self):
+            return str(super()._default_c())
+
+    with pytest.raises(TypeError):
+        B().c
 
 
 def no_atom():


### PR DESCRIPTION
As discussed in #127 this is backward incompatible for ReadOnly with a default but the fix is simple (use a keyword) and I assume it is not the most common use case since Constant fill that role (but I may be wrong).

Validating constant can also be interesting when a factory of method is generating the default value.