### PR TITLE
Allow members to be aliased under a different name via a metaclass

### DIFF
--- a/atom/atom.py
+++ b/atom/atom.py
@@ -264,12 +264,15 @@ class AtomMeta(type):
         # classes will overlap. When this happens, the members which
         # conflict must be cloned in order to occupy a unique index.
         conflicts = []
-        occupied = set()
+        occupied = {}
         for member in members.values():
-            if member.index in occupied:
-                conflicts.append(member)
+            other = occupied.get(member.index)
+            if other is None:
+                occupied[member.index] = member
+            elif other is member:
+                pass  # Alias to another member
             else:
-                occupied.add(member.index)
+                conflicts.append(member)
 
         # Clone the conflicting members and give them a unique index.
         # Do not blow away an overridden item on the current class.

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -19,7 +19,15 @@ from textwrap import dedent
 
 import pytest
 
-from atom.api import Atom, AtomMeta, Int, MissingMemberWarning, Value, atomref, set_default
+from atom.api import (
+    Atom,
+    AtomMeta,
+    Int,
+    MissingMemberWarning,
+    Value,
+    atomref,
+    set_default,
+)
 from atom.atom import observe
 
 
@@ -195,15 +203,15 @@ def test_traverse_atom():
 
 
 def test_aliased_member():
-    """ Test that reassigning a member does not break the index. """
+    """Test that reassigning a member does not break the index."""
 
     class CustomMeta(AtomMeta):
         def __new__(meta, name, bases, dct):
             cls = AtomMeta.__new__(meta, name, bases, dct)
             members = cls.members()
             for m in members.values():
-                if m.name != '_id' and m.metadata and m.metadata.get('pk'):
-                    cls._id = members['_id'] = m
+                if m.name != "_id" and m.metadata and m.metadata.get("pk"):
+                    cls._id = members["_id"] = m
             return cls
 
     class Base(Atom, metaclass=CustomMeta):
@@ -223,7 +231,7 @@ def test_aliased_member():
 
     # Validate the index
     for cls in (A, B):
-        print('Validating %s index' % cls)
+        print("Validating %s index" % cls)
         assert cls._id is cls.id
         member_map = {m: m.index for m in cls.members().values()}
         occupied = set()


### PR DESCRIPTION
When a duplicate member (where `a is b`, not a clone) is in the members list, the member index calculation can become invalid as the member is counted multiple times. 

This prevents intentionally "aliased" members from being reindexed.  For context atom-db uses  `_id` as an alias to whatever the member the user tags with `primary_key=True`.  I was getting weird errors in finally traced it down to this...  

Or any please let me know if there's any suggestions on a better way to alias a member...