### PR TITLE
Fix handling of bare typing.Iterable in Instance member

### DIFF
--- a/atom/typing_utils.py
+++ b/atom/typing_utils.py
@@ -1,5 +1,5 @@
 # --------------------------------------------------------------------------------------
-# Copyright (c) 2021, Nucleic Development Team.
+# Copyright (c) 2021-2022, Nucleic Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,9 +7,12 @@
 # --------------------------------------------------------------------------------------
 import sys
 from itertools import chain
-from typing import Any, List, Tuple, TypeVar, Union
 
-GENERICS: Tuple[Any, ...] = (type(List[int]),)
+# This is not a public member but neither are _GenericAlias not _SpecialGenericAlias
+from typing import _BaseGenericAlias  # type: ignore
+from typing import Any, Iterable, List, Tuple, TypeVar, Union
+
+GENERICS: Tuple[Any, ...] = (_BaseGenericAlias,)
 UNION = ()
 
 if sys.version_info < (3, 8):

--- a/atom/typing_utils.py
+++ b/atom/typing_utils.py
@@ -7,7 +7,7 @@
 # --------------------------------------------------------------------------------------
 import sys
 from itertools import chain
-from typing import Any, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, List, Tuple, TypeVar, Union
 
 # In Python 3.9+, List is a _SpecialGenericAlias and does not inherit from
 # _GenericAlias which is the type of List[int] for example

--- a/atom/typing_utils.py
+++ b/atom/typing_utils.py
@@ -7,12 +7,11 @@
 # --------------------------------------------------------------------------------------
 import sys
 from itertools import chain
-
-# This is not a public member but neither are _GenericAlias not _SpecialGenericAlias
-from typing import _BaseGenericAlias  # type: ignore
 from typing import Any, Iterable, List, Tuple, TypeVar, Union
 
-GENERICS: Tuple[Any, ...] = (_BaseGenericAlias,)
+# In Python 3.9+, List is a _SpecialGenericAlias and does not inherit from
+# _GenericAlias which is the type of List[int] for example
+GENERICS: Tuple[Any, ...] = (type(List), type(List[int]))
 UNION = ()
 
 if sys.version_info < (3, 8):

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -11,6 +11,8 @@ Atom Release Notes
 - make the setup compatible with PEP 517 PR #141
   Pip should be used for development install in place of directly calling
   setup.py
+- fix handling of _SpecialGenericAlias (typing.Sequence, ...) when used inside
+  an Instance member PR #151
 
 
 0.7.0 - 21/11/2021

--- a/tests/test_atomdict.py
+++ b/tests/test_atomdict.py
@@ -54,7 +54,7 @@ def test_repr(atom_dict, member):
     """Test the repr."""
     d = getattr(atom_dict.__class__, member).default_value_mode[1]
     if not d:
-        d = {i: i ** 2 for i in range(10)}
+        d = {i: i**2 for i in range(10)}
         setattr(atom_dict, member, d)
     assert repr(getattr(atom_dict, member)) == repr(d)
 
@@ -64,7 +64,7 @@ def test_len(atom_dict, member):
     """Test the len."""
     d = getattr(atom_dict.__class__, member).default_value_mode[1]
     if not d:
-        d = {i: i ** 2 for i in range(10)}
+        d = {i: i**2 for i in range(10)}
         setattr(atom_dict, member, d)
     assert len(getattr(atom_dict, member)) == len(d)
 
@@ -72,7 +72,7 @@ def test_len(atom_dict, member):
 @pytest.mark.parametrize("member", MEMBERS)
 def test_contains(atom_dict, member):
     """Test __contains__."""
-    d = {i: i ** 2 for i in range(10)}
+    d = {i: i**2 for i in range(10)}
     setattr(atom_dict, member, d)
     assert 5 in getattr(atom_dict, member)
     del getattr(atom_dict, member)[5]
@@ -84,7 +84,7 @@ def test_keys(atom_dict, member):
     """Test the keys."""
     d = getattr(atom_dict.__class__, member).default_value_mode[1]
     if not d:
-        d = {i: i ** 2 for i in range(10)}
+        d = {i: i**2 for i in range(10)}
         setattr(atom_dict, member, d)
     assert getattr(atom_dict, member).keys() == d.keys()
 
@@ -94,7 +94,7 @@ def test_copy(atom_dict, member):
     """Test copy."""
     d = getattr(atom_dict.__class__, member).default_value_mode[1]
     if not d:
-        d = {i: i ** 2 for i in range(10)}
+        d = {i: i**2 for i in range(10)}
         setattr(atom_dict, member, d)
     assert getattr(atom_dict, member).copy() == d
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -39,7 +39,7 @@
 
 """
 import sys
-from typing import Optional, Set as TSet, Union
+from typing import List as TList, Optional, Sequence, Set as TSet, Union
 
 import pytest
 
@@ -169,6 +169,8 @@ def c(x: object) -> int:
             [""],
         ),
         (Instance((int, float), optional=False), [1, 2.0], [1, 2.0], [None, ""]),
+        (Instance(TList[int], optional=False), [[1]], [[1]], [None, ""]),
+        (Instance(Sequence[int], optional=False), [[1]], [[1]], [None, 1]),
         (ForwardInstance(lambda: (int, float)), [1, 2.0, None], [1, 2.0, None], [""]),
         (ForwardInstance(lambda: (int, float), ()), [1, 2.0], [1, 2.0], ["", None]),
         (

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -115,10 +115,10 @@ def c(x: object) -> int:
         (FloatRange(0.0), [0.0, 0.6], [0.0, 0.6], [-0.1, ""]),
         (FloatRange(high=0.5), [-0.3, 0.5], [-0.3, 0.5], [0.6]),
         (FloatRange(1.0, 10.0, strict=True), [1.0, 3.7], [1.0, 3.7], [2, 4, 0, -11]),
-        (Bytes(strict=False), [b"a", u"a"], [b"a"] * 2, [1]),
-        (Bytes(), [b"a"], [b"a"], [u"a"]),
-        (Str(strict=False), [b"a", u"a"], ["a"] * 2, [1]),
-        (Str(), [u"a"], ["a"], [b"a"]),
+        (Bytes(strict=False), [b"a", "a"], [b"a"] * 2, [1]),
+        (Bytes(), [b"a"], [b"a"], ["a"]),
+        (Str(strict=False), [b"a", "a"], ["a"] * 2, [1]),
+        (Str(), ["a"], ["a"], [b"a"]),
         (Enum(1, 2, "a"), [1, 2, "a"], [1, 2, "a"], [3]),
         (Callable(), [int, None], [int, None], [1]),
         # 3.9 subs and 3.10 union tests in test_typing_utils are sufficient
@@ -220,7 +220,7 @@ def test_validation_modes(member, set_values, values, raising_values):
     for rv in raising_values:
         with pytest.raises(
             OverflowError
-            if (isinstance(member, Int) and isinstance(rv, float) and rv > 2 ** 32)
+            if (isinstance(member, Int) and isinstance(rv, float) and rv > 2**32)
             else ValueError
             if isinstance(member, Enum)
             else TypeError


### PR DESCRIPTION
In 3.9+, bare typing types (typing.List) are not _GenericAlias like subscribed ones (typing.List[int]) but _SpecialGenericAlias and as a consequence where not properly handled by extract_types.