### PR TITLE
Typehint examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,26 +39,25 @@ jobs:
           pip install -r lint_requirements.txt
       - name: Isort
         run: |
-          isort atom -c
-          isort examples -c
-          isort tests -c
+          isort atom examples tests -c
       - name: Black
+        if: always()
         run: |
-          black atom --check
-          black examples --check
-          black tests --check
+          black atom examples tests --check
       - name: Flake8
+        if: always()
         run: |
-          flake8 atom
-          flake8 examples
-          flake8 tests
+          flake8 atom examples tests
       - name: Run Mypy
+        if: always()
         run: |
-          mypy atom
-          mypy examples
+          mypy atom examples
   types:
     name: Type checking
     runs-on: ubuntu-latest
+    needs:
+      - lint
+    if: needs.lint.result == 'success'
     strategy:
       matrix:
         python-version: ['3.8', '3.9']
@@ -90,10 +89,13 @@ jobs:
   tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}
+    needs:
+      - lint
+    if: needs.lint.result == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Get history and tags for SCM versioning to work

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install graphviz
         uses: ts-graphviz/setup-graphviz@v1
       - name: Build documentation
+        # Remove -W till the multiple reference can be fixed in Sphinx 4
         run: |
           mkdir docs_output;
-          sphinx-build docs/source docs_output -W -b html;
+          sphinx-build docs/source docs_output -b html;

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# pycharm project files
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/atom/annotation_utils.py
+++ b/atom/annotation_utils.py
@@ -1,0 +1,102 @@
+# --------------------------------------------------------------------------------------
+# Copyright (c) 2021-2022, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# --------------------------------------------------------------------------------------
+import collections.abc
+from typing import Any, ClassVar, Type
+
+from .catom import Member
+from .dict import Dict as ADict
+from .list import List as AList
+from .scalars import Bool, Bytes, Callable as ACallable, Float, Int, Str, Value
+from .set import Set as ASet
+from .subclass import Subclass
+from .typing_utils import extract_types, get_args, is_optional
+
+_NO_DEFAULT = object()
+
+_TYPE_TO_MEMBER = {
+    bool: Bool,
+    int: Int,
+    float: Float,
+    str: Str,
+    bytes: Bytes,
+    list: AList,
+    dict: ADict,
+    set: ASet,
+    collections.abc.Callable: ACallable,
+}
+
+
+def generate_member_from_type_or_generic(
+    type_generic: Any, default: Any, annotate_type_containers: int
+) -> Member:
+    """Generate a member from a type or generic alias."""
+    types = extract_types(type_generic)
+    parameters = get_args(type_generic)
+
+    m_kwargs = {}
+
+    m_cls: Type[Member]
+    if object in types or Any in types:
+        m_cls = Value
+    # Int, Float, Str, Bytes, List, Dict, Set, Tuple, Bool, Callable
+    elif len(types) == 1 and types[0] in _TYPE_TO_MEMBER:
+        t = types[0]
+        m_cls = _TYPE_TO_MEMBER[t]
+        if annotate_type_containers and t in (list, dict, set, tuple):
+            # We can only validate homogeneous tuple so far so we ignore other cases
+            if t is tuple:
+                if (...) in parameters or len(set(parameters)) == 1:
+                    parameters = (parameters[0],)
+                else:
+                    parameters = ()
+            parameters = tuple(
+                generate_member_from_type_or_generic(
+                    t, _NO_DEFAULT, annotate_type_containers - 1
+                )
+                if t not in (Any, object)
+                else None
+                for t in parameters
+            )
+        else:
+            parameters = ()
+
+    # The value was annotated with Type[T] so we use a subclass
+    elif all(t is type for t in types):
+        m_cls = Subclass
+    else:
+        from .instance import Instance  # delayed to avoid circular import
+
+        # We cannot determine if a type has a trivial __instancecheck__ or not so
+        # we always use Instance since Typed will fail to validate with generic types
+        # such as collections.Iterable
+        m_cls = Instance
+
+        opt, parameters = is_optional(types)
+        m_kwargs["optional"] = opt
+        if default is not _NO_DEFAULT:
+            raise ValueError("Members requiring Instance cannot have a default value.")
+
+    if default is not _NO_DEFAULT:
+        m_kwargs["default"] = default
+
+    return m_cls(*parameters, **m_kwargs)
+
+
+def generate_members_from_cls_namespace(namespace, annotate_type_containers):
+    """Generate the member corresponding to a type annotation."""
+    annotations = namespace["__annotations__"]
+
+    for name, ann in annotations.items():
+        default = namespace.get(name, _NO_DEFAULT)
+        # We skip field for which a member was already provided or annotations
+        # corresponding to class variables.
+        if isinstance(default, Member) or getattr(ann, "__origin__", None) is ClassVar:
+            continue
+        namespace[name] = generate_member_from_type_or_generic(
+            ann, default, annotate_type_containers
+        )

--- a/atom/atom.py
+++ b/atom/atom.py
@@ -17,10 +17,13 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    MutableMapping,
     Optional,
     Tuple,
+    Union,
 )
 
+from .annotation_utils import generate_members_from_cls_namespace
 from .catom import (
     CAtom,
     DefaultValue,
@@ -195,7 +198,7 @@ class MissingMemberWarning(UserWarning):
 
 
 def _signal_missing_member(
-    owner: CAtom, method: str, members: List[str], prefix: str
+    owner: "AtomMeta", method: str, members: Mapping[str, Member], prefix: str
 ) -> None:
     warnings.warn(
         f"{prefix} method {method} on {owner} does not match any member "
@@ -219,12 +222,27 @@ class AtomMeta(type):
 
     """
 
-    def __new__(meta, name, bases, dct):  # noqa: C901
+    __atom_members__: Mapping[str, Member]
+
+    def __new__(  # noqa: C901
+        meta,
+        name: str,
+        bases: Tuple[type, ...],
+        dct: Dict[str, Any],
+        enable_weakrefs: bool = False,
+        use_annotations: bool = True,
+        type_containers: int = 1,
+    ):
         # Unless the developer requests slots, they are automatically
         # turned off. This prevents the creation of instance dicts and
         # other space consuming features unless explicitly requested.
         if "__slots__" not in dct:
             dct["__slots__"] = ()
+        if enable_weakrefs:
+            dct["__slots__"] += ("__weakref__",)
+
+        if use_annotations and "__annotations__" in dct:
+            generate_members_from_cls_namespace(dct, type_containers)
 
         # Pass over the class dict once and collect the information
         # necessary to implement the various behaviors. Some objects
@@ -274,6 +292,7 @@ class AtomMeta(type):
         # Remove the sentinels from the dict before creating the class.
         # The sentinels for the @observe decorators are already removed.
         for s in seen_sentinels:
+            assert s.name
             del dct[s.name]
 
         # Create the class object.
@@ -282,10 +301,12 @@ class AtomMeta(type):
         # Walk the mro of the class, excluding itself, in reverse order
         # collecting all of the members into a single dict. The reverse
         # update preserves the mro of overridden members.
-        members = {}
+        members: MutableMapping[str, Member] = {}
         for base in reversed(cls.__mro__[1:-1]):
             if base is not CAtom and issubclass(base, CAtom):
-                members.update(base.__atom_members__)
+                # Except if somebody abuses the system and create a non-Atom subclass
+                # of CAtom, this works
+                members.update(base.__atom_members__)  # type: ignore
 
         # The set of members which live on this class as opposed to a
         # base class. This enables the code which hooks up the various
@@ -350,6 +371,7 @@ class AtomMeta(type):
 
         # set_default() sentinels
         for sd in set_defaults:
+            assert sd.name  # At this point the name has been set
             if sd.name not in members:
                 msg = "Invalid call to set_default(). '%s' is not a member "
                 msg += "on the '%s' class."
@@ -419,9 +441,11 @@ class AtomMeta(type):
 
         # @observe decorated methods
         for handler in decorated:
+            assert handler.funcname  # Set at this point
             for name, attr in handler.pairs:
                 if name in members:
                     member = clone_if_needed(members[name])
+                    observer: Union[str, Callable[..., None]]
                     observer = handler.funcname
                     if attr is not None:
                         observer = ExtendedObserver(observer, attr)
@@ -460,15 +484,15 @@ class Atom(CAtom, metaclass=AtomMeta):
 
     """
 
-    __atom_members__: ClassVar[Dict[str, Member]]
+    __atom_members__: ClassVar[Mapping[str, Member]]
 
     @classmethod
-    def members(cls) -> Dict[str, Member]:
+    def members(cls) -> Mapping[str, Member]:
         """Get the members dictionary for the type.
 
         Returns
         -------
-        result : dict
+        result : Mapping[str, Member]
             The dictionary of members defined on the class. User code
             should not modify the contents of the dict.
 

--- a/atom/catom.pyi
+++ b/atom/catom.pyi
@@ -220,7 +220,7 @@ class Member(Generic[T, S]):
         mode: Literal[PostGetAttr.ObjectMethod_Value]
         | Literal[PostGetAttr.ObjectMethod_NameValue]
         | Literal[PostGetAttr.MemberMethod_ObjectValue],
-        context: Member,
+        context: str,
     ) -> None: ...
     # Post setattr mode
     @overload

--- a/atom/typing_utils.py
+++ b/atom/typing_utils.py
@@ -7,23 +7,12 @@
 # --------------------------------------------------------------------------------------
 import sys
 from itertools import chain
-from typing import Any, List, Tuple, TypeVar, Union
+from typing import Any, List, Tuple, TypeVar, Union, get_args, get_origin
 
 # In Python 3.9+, List is a _SpecialGenericAlias and does not inherit from
 # _GenericAlias which is the type of List[int] for example
 GENERICS: Tuple[Any, ...] = (type(List), type(List[int]))
 UNION = ()
-
-if sys.version_info < (3, 8):
-
-    def get_origin(t):
-        return t.__origin__
-
-    def get_args(t):
-        return t.__args__
-
-else:
-    from typing import get_args, get_origin
 
 if sys.version_info >= (3, 9):
     from types import GenericAlias

--- a/examples/typehints/person.py
+++ b/examples/typehints/person.py
@@ -1,0 +1,51 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2013-2022, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ------------------------------------------------------------------------------
+"""Person tutorial using type hints
+
+"""
+
+from typing import Optional
+
+from atom.api import Atom
+from atom.api import Range
+from atom.api import observe
+
+
+class Person(Atom):
+    """ A simple class representing a person object."""
+
+    last_name: str
+
+    first_name: str
+
+    middle_name: Optional[str] = None
+
+    age = Range(low=0)
+
+    debug: bool = False
+
+    @observe("age")
+    def debug_print(self, change):
+        """ Prints out a debug message whenever the person's age changes.
+        """
+        if self.debug:
+            templ = "{first} {middle} {last} is {age} years old."
+            s = templ.format(
+                first=self.first_name,
+                middle=self.middle_name,
+                last=self.last_name,
+                age=self.age,
+            )
+
+            print(s)
+
+
+if __name__ == '__main__':
+    john = Person(first_name='John', last_name='Doe', age=42)
+    john.debug = True
+    john.age = 43

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 name = "atom"
 description = "Memory efficient Python objects"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
   {name = "The Nucleic Development Team", email = "sccolbert@gmail.com"}
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -19,8 +19,15 @@ from textwrap import dedent
 
 import pytest
 
-from atom.api import Atom, Int, MissingMemberWarning, Value, atomref, set_default
-from atom.atom import observe
+from atom.api import (
+    Atom,
+    Int,
+    MissingMemberWarning,
+    Value,
+    atomref,
+    observe,
+    set_default,
+)
 
 
 def test_init():
@@ -236,3 +243,10 @@ def test_warn_on_missing_observe():
 
     with pytest.warns(MissingMemberWarning):
         exec(src, globals(), {"Atom": Atom, "observe": observe})
+
+
+def test_enable_weakref():
+    class WA(Atom, enable_weakrefs=True):
+        pass
+
+    assert "__weakref__" in WA.__slots__

--- a/tests/test_atom_from_annotations.py
+++ b/tests/test_atom_from_annotations.py
@@ -8,8 +8,14 @@
 """Test defining an atom class using typing annotations.
 
 """
-from collections.abc import Callable as TCallable
-from typing import Any, Dict as TDict, Iterable, List as TList, Set as TSet
+from typing import (
+    Any,
+    Callable as TCallable,
+    Dict as TDict,
+    Iterable,
+    List as TList,
+    Set as TSet,
+)
 
 import pytest
 

--- a/tests/test_atom_from_annotations.py
+++ b/tests/test_atom_from_annotations.py
@@ -1,0 +1,130 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2021, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ------------------------------------------------------------------------------
+"""Test defining an atom class using typing annotations.
+
+"""
+from collections.abc import Callable as TCallable
+from typing import Any, Dict as TDict, Iterable, List as TList, Set as TSet
+
+import pytest
+
+from atom.api import (
+    Atom,
+    Bool,
+    Bytes,
+    Callable,
+    Dict,
+    Float,
+    Instance,
+    Int,
+    List,
+    Set,
+    Str,
+    Value,
+)
+
+
+def test_ignore_annotations():
+    class A(Atom, use_annotations=False):
+        a: int
+
+    assert not hasattr(A, "a")
+
+
+@pytest.mark.parametrize(
+    "annotation, member",
+    [
+        (bool, Bool),
+        (int, Int),
+        (float, Float),
+        (str, Str),
+        (bytes, Bytes),
+        (Any, Value),
+        (object, Value),
+        (TCallable, Callable),
+        (TCallable[[int], int], Callable),
+        (Iterable, Instance),
+    ],
+)
+def test_annotation_use(annotation, member):
+    class A(Atom):
+        a: annotation
+
+    assert isinstance(A.a, member)
+    if member is Instance:
+        assert A.a.validate_mode[1] == (annotation.__origin__,)
+    else:
+        assert A.a.default_value_mode == member().default_value_mode
+
+
+@pytest.mark.parametrize(
+    "annotation, member, depth",
+    [
+        (TList[int], List(), 0),
+        (TList[int], List(Int()), 1),
+        (TList[TList[int]], List(List()), 1),
+        (TList[TList[int]], List(List(Int())), -1),
+        (TSet[int], Set(), 0),
+        (TSet[int], Set(Int()), 1),
+        (TDict[int, int], Dict(), 0),
+        (TDict[int, int], Dict(Int(), Int()), 1),
+    ],
+)
+def test_annotated_containers_no_default(annotation, member, depth):
+    class A(Atom, type_containers=depth):
+        a: annotation
+
+    assert isinstance(A.a, type(member))
+    if depth == 0:
+        if isinstance(member, Dict):
+            assert A.a.validate_mode[1] == (None, None)
+        else:
+            assert A.a.item is None
+    else:
+        if isinstance(member, Dict):
+            for (k, v), (mk, mv) in zip(
+                A.a.validate_mode[1:], member.validate_mode[1:]
+            ):
+                assert type(k) is type(mk)
+                assert type(v) is type(mv)
+
+        else:
+            assert type(A.a.item) is type(member.item)  # noqa: E721
+            if isinstance(member.item, List):
+                assert type(A.a.item.item) is type(member.item.item)  # noqa: E721
+
+
+@pytest.mark.parametrize(
+    "annotation, member, default",
+    [
+        (bool, Bool, True),
+        (int, Int, 1),
+        (float, Float, 1.0),
+        (str, Str, "a"),
+        (bytes, Bytes, b"a"),
+        (Any, Value, 1),
+        (object, Value, 2),
+        (TCallable, Callable, lambda x: x),
+        (TList, List, [1]),
+        (TSet, Set, {1}),
+        (TDict, Dict, {1: 2}),
+    ],
+)
+def test_annotations_with_default(annotation, member, default):
+    class A(Atom):
+        a: annotation = default
+
+    assert isinstance(A.a, member)
+    assert A.a.default_value_mode == member(default=default).default_value_mode
+
+
+def test_annotations_no_default_for_instance():
+    with pytest.raises(ValueError):
+
+        class A(Atom):
+            a: Iterable = []

--- a/tests/typing/test_optional.py
+++ b/tests/typing/test_optional.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from atom.api import Atom
+
+
+class InventoryAtom(Atom):
+    """Class for keeping track of an item in inventory."""
+    name: str
+    unit_price: float
+    quantity_sold: Optional[int]
+    quantity_on_hand: int = 2
+
+
+@dataclass
+class InventoryDataclass:
+    """Class for keeping track of an item in inventory."""
+    name: str
+    unit_price: float
+    quantity_sold: Optional[int]
+    quantity_on_hand: int = 2
+
+
+def test_constructor():
+    atm = InventoryDataclass(name='widget1', unit_price=0.99, quantity_on_hand=10, quantity_sold=1)
+    dcl = InventoryAtom(name='widget1', unit_price=0.99, quantity_on_hand=10, quantity_sold=1)
+
+    for obj in [atm, dcl]:
+        assert isinstance(obj.name, str)
+        assert isinstance(obj.unit_price, float)
+        assert isinstance(obj.quantity_on_hand, int)
+        assert isinstance(obj.quantity_sold, int)
+
+
+def test_default_value():
+    dcl = InventoryDataclass(name='widget1', unit_price=0.99, quantity_sold=1)
+    atm = InventoryAtom(name='widget1', unit_price=0.99, quantity_sold=1)
+
+    assert atm.quantity_on_hand == 2
+    assert dcl.quantity_on_hand == 2
+
+
+# @pytest.mark.skip("Optional members with default value should be respected")
+def test_optional_with_default_none_value():
+    """
+    Optional members with default value should be respected
+    """
+
+    @dataclass
+    class TestDataclass:
+        x: Optional[int] = None
+
+    class TestAtom(Atom):
+        x: Optional[int] = None
+
+    dcl = TestDataclass()
+    assert dcl.x is None
+
+    atm = TestAtom()
+    assert atm.x is None
+
+
+# @pytest.mark.skip("Optional members with no default should not be allowed")
+def test_optional_with_no_default():
+    @dataclass
+    class TestDataclass:
+        x: Optional[int]
+
+    class TestAtom(Atom):
+        x: Optional[int]
+
+    with pytest.raises(TypeError):
+        TestDataclass()
+
+    with pytest.raises(TypeError):
+        TestAtom()

--- a/tests/typing/test_optional.py
+++ b/tests/typing/test_optional.py
@@ -42,10 +42,10 @@ def test_default_value():
     assert dcl.quantity_on_hand == 2
 
 
-# @pytest.mark.skip("Optional members with default value should be respected")
 def test_optional_with_default_none_value():
-    """
-    Optional members with default value should be respected
+    """Optional members with default value should be respected
+
+    Fails but seems like it should not.
     """
 
     @dataclass
@@ -62,8 +62,15 @@ def test_optional_with_default_none_value():
     assert atm.x is None
 
 
-# @pytest.mark.skip("Optional members with no default should not be allowed")
 def test_optional_with_no_default():
+    """
+    This example highlights a possible difference between atom and dataclasses.
+
+    When a member/field is declared as Optional without a default:
+    A dataclass will raise a TypeError if the constructor does not have the argument.
+    Atom allows it, and sets the default value to None.
+
+    """
     @dataclass
     class TestDataclass:
         x: Optional[int]
@@ -74,5 +81,5 @@ def test_optional_with_no_default():
     with pytest.raises(TypeError):
         TestDataclass()
 
-    with pytest.raises(TypeError):
-        TestAtom()
+    atm = TestAtom()
+    assert atm.x is None


### PR DESCRIPTION
This branch builds off the [`type-hints` branch](https://github.com/nucleic/atom/tree/type-hints).

It has a simple example and a small test comparing some behavior to dataclasses for basic compatibility.

`tests/typing/test_optional.py`currently highlight two issues:

1. Different behavior when a member/field is declared as Optional without a default (`test_optional_with_no_default`): 
A dataclass will raise a TypeError if the constructor does not have the argument. 
Atom allows it, and sets the default value to None.  See `test_optional_with_no_default` for an example.
Seems like we should decide a preferred behavior and highlight any difference.  I kinda prefer how Atom does it.

2. The default value of Optional members is not respected (`test_optional_with_default_none_value`)
With dataclasses, the default value of an Optional field can include `None`. 
With atom, optional members with a default value raises an error:
`ValueError("Members requiring Instance cannot have a default value.")`
Seems like something we should honor the default value.