### PR TITLE
Type hint example and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# pycharm project files
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/examples/typehints/person.py
+++ b/examples/typehints/person.py
@@ -1,0 +1,51 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2013-2022, Nucleic Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ------------------------------------------------------------------------------
+"""Person tutorial using type hints
+
+"""
+
+from typing import Optional
+
+from atom.api import Atom
+from atom.api import Range
+from atom.api import observe
+
+
+class Person(Atom):
+    """ A simple class representing a person object."""
+
+    last_name: str
+
+    first_name: str
+
+    middle_name: Optional[str] = None
+
+    age = Range(low=0)
+
+    debug: bool = False
+
+    @observe("age")
+    def debug_print(self, change):
+        """ Prints out a debug message whenever the person's age changes.
+        """
+        if self.debug:
+            templ = "{first} {middle} {last} is {age} years old."
+            s = templ.format(
+                first=self.first_name,
+                middle=self.middle_name,
+                last=self.last_name,
+                age=self.age,
+            )
+
+            print(s)
+
+
+if __name__ == '__main__':
+    john = Person(first_name='John', last_name='Doe', age=42)
+    john.debug = True
+    john.age = 43

--- a/tests/typing/test_optional.py
+++ b/tests/typing/test_optional.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from atom.api import Atom
+
+
+class InventoryAtom(Atom):
+    """Class for keeping track of an item in inventory."""
+    name: str
+    unit_price: float
+    quantity_sold: Optional[int]
+    quantity_on_hand: int = 2
+
+
+@dataclass
+class InventoryDataclass:
+    """Class for keeping track of an item in inventory."""
+    name: str
+    unit_price: float
+    quantity_sold: Optional[int]
+    quantity_on_hand: int = 2
+
+
+def test_constructor():
+    atm = InventoryDataclass(name='widget1', unit_price=0.99, quantity_on_hand=10, quantity_sold=1)
+    dcl = InventoryAtom(name='widget1', unit_price=0.99, quantity_on_hand=10, quantity_sold=1)
+
+    for obj in [atm, dcl]:
+        assert isinstance(obj.name, str)
+        assert isinstance(obj.unit_price, float)
+        assert isinstance(obj.quantity_on_hand, int)
+        assert isinstance(obj.quantity_sold, int)
+
+
+def test_default_value():
+    dcl = InventoryDataclass(name='widget1', unit_price=0.99, quantity_sold=1)
+    atm = InventoryAtom(name='widget1', unit_price=0.99, quantity_sold=1)
+
+    assert atm.quantity_on_hand == 2
+    assert dcl.quantity_on_hand == 2
+
+
+# @pytest.mark.skip("Optional members with default value should be respected")
+def test_optional_with_default_none_value():
+    """
+    Optional members with default value should be respected
+    """
+
+    @dataclass
+    class TestDataclass:
+        x: Optional[int] = None
+
+    class TestAtom(Atom):
+        x: Optional[int] = None
+
+    dcl = TestDataclass()
+    assert dcl.x is None
+
+    atm = TestAtom()
+    assert atm.x is None
+
+
+# @pytest.mark.skip("Optional members with no default should not be allowed")
+def test_optional_with_no_default():
+    @dataclass
+    class TestDataclass:
+        x: Optional[int]
+
+    class TestAtom(Atom):
+        x: Optional[int]
+
+    with pytest.raises(TypeError):
+        TestDataclass()
+
+    with pytest.raises(TypeError):
+        TestAtom()

--- a/tests/typing/test_optional.py
+++ b/tests/typing/test_optional.py
@@ -42,10 +42,10 @@ def test_default_value():
     assert dcl.quantity_on_hand == 2
 
 
-# @pytest.mark.skip("Optional members with default value should be respected")
 def test_optional_with_default_none_value():
-    """
-    Optional members with default value should be respected
+    """Optional members with default value should be respected
+
+    Fails but seems like it should not.
     """
 
     @dataclass
@@ -62,8 +62,15 @@ def test_optional_with_default_none_value():
     assert atm.x is None
 
 
-# @pytest.mark.skip("Optional members with no default should not be allowed")
 def test_optional_with_no_default():
+    """
+    This example highlights a possible difference between atom and dataclasses.
+
+    When a member/field is declared as Optional without a default:
+    A dataclass will raise a TypeError if the constructor does not have the argument.
+    Atom allows it, and sets the default value to None.
+
+    """
     @dataclass
     class TestDataclass:
         x: Optional[int]
@@ -74,5 +81,5 @@ def test_optional_with_no_default():
     with pytest.raises(TypeError):
         TestDataclass()
 
-    with pytest.raises(TypeError):
-        TestAtom()
+    atm = TestAtom()
+    assert atm.x is None


### PR DESCRIPTION
This branch builds off the [`type-hints` branch](https://github.com/nucleic/atom/tree/type-hints).

It has a simple example and a small test comparing some behavior to dataclasses for basic compatibility.

`tests/typing/test_optional.py`currently highlight two issues:

1. Different behavior when a member/field is declared as Optional without a default (`test_optional_with_no_default`): 
A dataclass will raise a TypeError if the constructor does not have the argument. 
Atom allows it, and sets the default value to None.  See `test_optional_with_no_default` for an example.
Seems like we should decide a preferred behavior and highlight any difference.  I kinda prefer how Atom does it.

2. The default value of Optional members is not respected (`test_optional_with_default_none_value`)
With dataclasses, the default value of an Optional field can include `None`. 
With atom, optional members with a default value raises an error:
`ValueError("Members requiring Instance cannot have a default value.")`
Seems like something we should honor the default value.