### PR TITLE
atom: fix memory layout in the presense of multiple inheritance

### DIFF
--- a/atom/api.py
+++ b/atom/api.py
@@ -8,7 +8,7 @@
 """Module exporting the public interface to atom.
 
 """
-from .atom import Atom, AtomMeta, MissingMemberWarning, observe, set_default
+from .atom import Atom, AtomMeta, MissingMemberWarning, add_member, observe, set_default
 from .catom import (
     CAtom,
     ChangeType,
@@ -59,6 +59,7 @@ __all__ = [
     "Atom",
     "AtomMeta",
     "MissingMemberWarning",
+    "add_member",
     "observe",
     "set_default",
     "CAtom",

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -5,7 +5,8 @@ Atom Release Notes
 ------------------
 
 - fix the resolution order of members in the presence of multiple inheritance
-  with a common base class PR #165 #
+  with a common base class PR #165 #168
+
   Due to the above changes, adding a member after the class definition extra_requires
   more work than before. As a consequence a new helper function ``add_member`` has
   been added.

--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -1,11 +1,14 @@
 Atom Release Notes
 ==================
 
-0.8.1 - unreleased
+0.9.0 - unreleased
 ------------------
 
 - fix the resolution order of members in the presence of multiple inheritance
-  with a common base class PR #165
+  with a common base class PR #165 #
+  Due to the above changes, adding a member after the class definition extra_requires
+  more work than before. As a consequence a new helper function ``add_member`` has
+  been added.
 
 
 0.8.0 - 30/03/2022

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -25,6 +25,7 @@ from atom.api import (
     MissingMemberWarning,
     Str,
     Value,
+    add_member,
     atomref,
     observe,
     set_default,
@@ -103,6 +104,26 @@ def test_multi_inheritance():
                 continue
             assert m.index != m2.index
 
+    class Mixin(Atom):
+
+        i5 = Int()
+
+        i6 = Int()
+
+        i7 = Int()
+
+    class MultiNext(Multi, Mixin):
+
+        i1 = Int()
+
+    class MultiNext2(MultiNext):
+
+        i1 = Int()
+
+    assert sorted(m.index for m in MultiNext2.__atom_members__.values()) == list(
+        range(7)
+    )
+
 
 def test_member_mro_in_multiple_inheritance():
     """Test that we respect the MRO for members."""
@@ -134,6 +155,18 @@ def test_member_mro_in_multiple_inheritance():
         pass
 
     assert D().a == "b"
+
+
+def test_add_member():
+    class A(Atom):
+        pass
+
+    add_member(A, "a", Int())
+
+    class B(A):
+        pass
+
+    assert "a" in B().members()
 
 
 def test_cloning_members():


### PR DESCRIPTION
The resolution of the mro issue, led to the existence of holes in the index when inspecting only the specific members in the mro which led to inconsistent memory layouts.

Also add a helper to add members after a class is defined which is something we need in enaml.