### PR TITLE
Generate Tuple member from tuple annotation

### DIFF
--- a/atom/annotation_utils.py
+++ b/atom/annotation_utils.py
@@ -15,6 +15,7 @@ from .list import List as AList
 from .scalars import Bool, Bytes, Callable as ACallable, Float, Int, Str, Value
 from .set import Set as ASet
 from .subclass import Subclass
+from .tuple import Tuple as ATuple
 from .typing_utils import extract_types, get_args, is_optional
 
 _NO_DEFAULT = object()
@@ -28,6 +29,7 @@ _TYPE_TO_MEMBER = {
     list: AList,
     dict: ADict,
     set: ASet,
+    tuple: ATuple,
     collections.abc.Callable: ACallable,
 }
 

--- a/tests/test_atom_from_annotations.py
+++ b/tests/test_atom_from_annotations.py
@@ -18,6 +18,7 @@ from typing import (
     List as TList,
     Optional,
     Set as TSet,
+    Tuple as TTuple,
     Union,
 )
 
@@ -36,6 +37,7 @@ from atom.api import (
     Member,
     Set,
     Str,
+    Tuple,
     Value,
 )
 from atom.atom import set_default
@@ -181,6 +183,11 @@ def test_union_in_annotation(annotation, validate_mode):
         (TSet[int], Set(Int()), 1),
         (TDict[int, int], Dict(), 0),
         (TDict[int, int], Dict(Int(), Int()), 1),
+        (TTuple[int], Tuple(), 0),
+        (TTuple[int], Tuple(Int()), 1),
+        (TTuple[int, ...], Tuple(Int()), 1),
+        (TTuple[int, float], Tuple(), 1),
+        (TTuple[tuple, int], Tuple(), 1),
     ],
 )
 def test_annotated_containers_no_default(annotation, member, depth):


### PR DESCRIPTION
We do not runtime validate tuples with more than one element which are not of variable length. We could but it would still not reflect the reality since we would need a different member for that.