### PR TITLE
Rework CAtom_setstate

### DIFF
--- a/atom/src/catom.cpp
+++ b/atom/src/catom.cpp
@@ -445,15 +445,10 @@ CAtom_getstate( CAtom* self )
 }
 
 PyObject*
-CAtom_setstate( CAtom* self, PyObject* args )
+CAtom_setstate( CAtom* self, PyObject* state )
 {
-    if( PyTuple_GET_SIZE( args ) != 1 )
-        return cppy::type_error( "__setstate__() takes exactly one argument" );
-    PyObject* state = PyTuple_GET_ITEM( args, 0 );
-    cppy::ptr itemsptr = PyMapping_Items(state);
-    if ( !itemsptr )
-        return 0;
-    cppy::ptr selfptr(pyobject_cast(self), true);
+    if ( !PyMapping_Check(state) )
+        return cppy::type_error("__setstate__ requires a mapping");
 
     // If the -f key is present freeze the object
     bool frozen = PyMapping_HasKey(state, atom_flags);
@@ -463,11 +458,17 @@ CAtom_setstate( CAtom* self, PyObject* args )
             return 0;
     }
 
-    for ( Py_ssize_t i = 0; i < PyMapping_Size(state); i++ ) {
-        PyObject* item = PyList_GET_ITEM(itemsptr.get(), i);
-        PyObject* key = PyTuple_GET_ITEM(item , 0);
-        PyObject* value = PyTuple_GET_ITEM(item , 1);
-        if ( !selfptr.setattr(key, value) )
+    cppy::ptr iter( PyObject_GetIter(state) );
+    if ( !iter )
+        return 0;
+
+    cppy::ptr key;
+    while ( ( key = PyIter_Next( iter.get() ) ) )
+    {
+        cppy::ptr value( PyObject_GetItem( state, key.get() ) );
+        if ( !value )
+            return 0;
+        if ( PyObject_SetAttr( pyobject_cast(self), key.get(), value.get() ) )
             return 0;
     }
 
@@ -501,7 +502,7 @@ CAtom_methods[] = {
       "__sizeof__() -> size of object in memory, in bytes" },
     { "__getstate__", ( PyCFunction )CAtom_getstate, METH_NOARGS,
       "The base implementation of the pickle getstate protocol." },
-    { "__setstate__", ( PyCFunction )CAtom_setstate, METH_VARARGS,
+    { "__setstate__", ( PyCFunction )CAtom_setstate, METH_O,
       "The base implementation of the pickle setstate protocol." },
     { 0 } // sentinel
 };

--- a/atom/src/catom.cpp
+++ b/atom/src/catom.cpp
@@ -451,7 +451,13 @@ CAtom_setstate( CAtom* self, PyObject* state )
         return cppy::type_error("__setstate__ requires a mapping");
 
     // If the -f key is present freeze the object
-    bool frozen = PyMapping_HasKey(state, atom_flags);
+#if PY_VERSION_HEX >= 0x030D0000
+    int frozen = PyMapping_HasKeyWithError( state, atom_flags );
+    if ( frozen == -1 )
+        return 0;
+#else
+    int frozen = PyMapping_HasKey( state, atom_flags );
+#endif
     if ( frozen )
     {
         if ( PyMapping_DelItem(state, atom_flags) == -1 )

--- a/tests/test_get_set_state.py
+++ b/tests/test_get_set_state.py
@@ -308,9 +308,9 @@ def test_setstate_errors(caplog):
         t.__setstate__()  # Incorrect number of args
     with pytest.raises(TypeError):
         t.__setstate__({}, False)  # Incorrect number of args
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         t.__setstate__(None)  # Not a mapping (no items() method)
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         t.__setstate__(["z"])  # Not a mapping (has no items() method)
     with pytest.raises(AttributeError):
         t.__setstate__({"z": 3})  # Invalid attribute


### PR DESCRIPTION
Any suggestions for improvements are welcome:
1. PyMapping_Check is kind of broken so tuples and lists pass it
2. As mentioned in the other PR setattr triggers notifications
3. I don't like how it modifies the passed in state by deleting the frozen flag but checking every key makes it a lot slower (~30%)