### PR TITLE
Correct handler range checks

### DIFF
--- a/atom/src/behaviors.h
+++ b/atom/src/behaviors.h
@@ -205,8 +205,28 @@ enum Mode: uint8_t
     Property,
     ObjectMethod_Name,
     MemberMethod_Object,
+    Last // sentinel
 };
 
 }  // namespace GetState
+
+constexpr uint8_t _required_handler_size(uint8_t x) {
+    return (
+        (x > 128) ? 255 :
+        (x > 64) ? 128 :
+        (x > 32) ? 64 :
+        (x > 16) ? 32 :
+        (x > 8) ? 16 :
+        (x > 4) ? 8 :
+        (x > 2) ? 4 :
+        2
+    );
+}
+
+#define _handlers_size( a ) ( sizeof(a) / sizeof(a[0]) )
+#define validate_handlers( handlers, sentinel ) \
+    _handlers_size(handlers) - 1; \
+    static_assert(sentinel <= _handlers_size(handlers), "Not enough handlers for all enum values"); \
+    static_assert(_required_handler_size(sentinel) == _handlers_size(handlers), "Handlers size does not match enum width") \
 
 }  // namespace atom

--- a/atom/src/defaultvaluebehavior.cpp
+++ b/atom/src/defaultvaluebehavior.cpp
@@ -202,9 +202,12 @@ handlers[] = {
     call_object_object_name_handler,
     object_method_handler,
     object_method_name_handler,
-    member_method_object_handler
+    member_method_object_handler,
+    no_op_handler,
+    no_op_handler
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
 
 }  // namespace
 
@@ -212,9 +215,7 @@ handlers[] = {
 PyObject*
 Member::default_value( CAtom* atom )
 {
-    if( get_default_value_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom );  // LCOV_EXCL_LINE
-    return handlers[ get_default_value_mode() ]( this, atom );
+    return handlers[ get_default_value_mode() & 0xf ]( this, atom );
 }
 
 

--- a/atom/src/defaultvaluebehavior.cpp
+++ b/atom/src/defaultvaluebehavior.cpp
@@ -207,7 +207,7 @@ handlers[] = {
     no_op_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
+const auto mask = validate_handlers(handlers, DefaultValue::Mode::Last);
 
 }  // namespace
 
@@ -215,7 +215,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 han
 PyObject*
 Member::default_value( CAtom* atom )
 {
-    return handlers[ get_default_value_mode() & 0xf ]( this, atom );
+    return handlers[ get_default_value_mode() & mask ]( this, atom );
 }
 
 

--- a/atom/src/delattrbehavior.cpp
+++ b/atom/src/delattrbehavior.cpp
@@ -192,7 +192,7 @@ handlers[] = {
     property_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
+const auto mask = validate_handlers(handlers, DelAttr::Mode::Last);
 
 }  // namespace
 
@@ -200,7 +200,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handl
 int
 Member::delattr( CAtom* atom )
 {
-    return handlers[ get_delattr_mode() & 0x7 ]( this, atom );
+    return handlers[ get_delattr_mode() & mask ]( this, atom );
 }
 
 

--- a/atom/src/delattrbehavior.cpp
+++ b/atom/src/delattrbehavior.cpp
@@ -192,6 +192,7 @@ handlers[] = {
     property_handler
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
 
 }  // namespace
 
@@ -199,9 +200,7 @@ handlers[] = {
 int
 Member::delattr( CAtom* atom )
 {
-    if( get_delattr_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom );  // LCOV_EXCL_LINE
-    return handlers[ get_delattr_mode() ]( this, atom );
+    return handlers[ get_delattr_mode() & 0x7 ]( this, atom );
 }
 
 

--- a/atom/src/getattrbehavior.cpp
+++ b/atom/src/getattrbehavior.cpp
@@ -256,8 +256,14 @@ handlers[] = {
     call_object_object_name_handler,
     object_method_handler,
     object_method_name_handler,
-    member_method_object_handler
+    member_method_object_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler
 };
+
+static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
 
 }  // namespace
 
@@ -265,9 +271,7 @@ handlers[] = {
 PyObject*
 Member::getattr( CAtom* atom )
 {
-    if( get_getattr_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom );  // LCOV_EXCL_LINE
-    return handlers[ get_getattr_mode() ]( this, atom );
+    return handlers[ get_getattr_mode() & 0xf ]( this, atom );
 }
 
 }  // namespace atom

--- a/atom/src/getattrbehavior.cpp
+++ b/atom/src/getattrbehavior.cpp
@@ -263,7 +263,7 @@ handlers[] = {
     no_op_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
+const auto mask = validate_handlers(handlers, GetAttr::Mode::Last);
 
 }  // namespace
 
@@ -271,7 +271,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 han
 PyObject*
 Member::getattr( CAtom* atom )
 {
-    return handlers[ get_getattr_mode() & 0xf ]( this, atom );
+    return handlers[ get_getattr_mode() & mask ]( this, atom );
 }
 
 }  // namespace atom

--- a/atom/src/getstatebehavior.cpp
+++ b/atom/src/getstatebehavior.cpp
@@ -129,7 +129,7 @@ handlers[] = {
     include_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
+const auto mask = validate_handlers(handlers, GetState::Mode::Last);
 
 }  // namespace
 
@@ -137,7 +137,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handl
 PyObject*
 Member::should_getstate( CAtom* atom )
 {
-    return handlers[ get_getstate_mode() & 0x7 ]( this, atom );
+    return handlers[ get_getstate_mode() & mask ]( this, atom );
 }
 
 }  // namespace atom

--- a/atom/src/getstatebehavior.cpp
+++ b/atom/src/getstatebehavior.cpp
@@ -124,8 +124,12 @@ handlers[] = {
     include_non_default_handler,
     property_handler,
     object_method_name_handler,
-    member_method_object_handler
+    member_method_object_handler,
+    include_handler,
+    include_handler
 };
+
+static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
 
 }  // namespace
 
@@ -133,9 +137,7 @@ handlers[] = {
 PyObject*
 Member::should_getstate( CAtom* atom )
 {
-    if( get_getstate_mode() >= sizeof( handlers ) )
-        return include_handler( this, atom );  // LCOV_EXCL_LINE
-    return handlers[ get_getstate_mode() ]( this, atom );
+    return handlers[ get_getstate_mode() & 0x7 ]( this, atom );
 }
 
 }  // namespace atom

--- a/atom/src/postgetattrbehavior.cpp
+++ b/atom/src/postgetattrbehavior.cpp
@@ -99,7 +99,7 @@ handlers[] = {
     no_op_handler,
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
+const auto mask = validate_handlers(handlers, PostGetAttr::Mode::Last);
 
 }  // namespace
 
@@ -107,7 +107,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handl
 PyObject*
 Member::post_getattr( CAtom* atom, PyObject* value )
 {
-    return handlers[ get_post_getattr_mode() & 0x7 ]( this, atom, value );
+    return handlers[ get_post_getattr_mode() & mask ]( this, atom, value );
 }
 
 

--- a/atom/src/postgetattrbehavior.cpp
+++ b/atom/src/postgetattrbehavior.cpp
@@ -93,9 +93,13 @@ handlers[] = {
     delegate_handler,
     object_method_value_handler,
     object_method_name_value_handler,
-    member_method_object_value_handler
+    member_method_object_value_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler,
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
 
 }  // namespace
 
@@ -103,9 +107,7 @@ handlers[] = {
 PyObject*
 Member::post_getattr( CAtom* atom, PyObject* value )
 {
-    if( get_post_getattr_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom, value );  // LCOV_EXCL_LINE
-    return handlers[ get_post_getattr_mode() ]( this, atom, value );
+    return handlers[ get_post_getattr_mode() & 0x7 ]( this, atom, value );
 }
 
 

--- a/atom/src/postsetattrbehavior.cpp
+++ b/atom/src/postsetattrbehavior.cpp
@@ -112,7 +112,7 @@ handlers[] = {
     no_op_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
+const auto mask = validate_handlers(handlers, PostSetAttr::Mode::Last);
 
 }  // namespace
 
@@ -120,7 +120,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handl
 int
 Member::post_setattr( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    return handlers[ get_post_setattr_mode() & 0x7 ]( this, atom, oldvalue, newvalue );
+    return handlers[ get_post_setattr_mode() & mask ]( this, atom, oldvalue, newvalue );
 }
 
 

--- a/atom/src/postsetattrbehavior.cpp
+++ b/atom/src/postsetattrbehavior.cpp
@@ -106,9 +106,13 @@ handlers[] = {
     delegate_handler,
     object_method_old_new_handler,
     object_method_name_old_new_handler,
-    member_method_object_old_new_handler
+    member_method_object_old_new_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
 
 }  // namespace
 
@@ -116,9 +120,7 @@ handlers[] = {
 int
 Member::post_setattr( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    if( get_post_setattr_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom, oldvalue, newvalue );  // LCOV_EXCL_LINE
-    return handlers[ get_post_setattr_mode() ]( this, atom, oldvalue, newvalue );
+    return handlers[ get_post_setattr_mode() & 0x7 ]( this, atom, oldvalue, newvalue );
 }
 
 

--- a/atom/src/postvalidatebehavior.cpp
+++ b/atom/src/postvalidatebehavior.cpp
@@ -97,9 +97,13 @@ handlers[] = {
     delegate_handler,
     object_method_old_new_handler,
     object_method_name_old_new_handler,
-    member_method_object_old_new_handler
+    member_method_object_old_new_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
 
 }  // namespace
 
@@ -107,9 +111,7 @@ handlers[] = {
 PyObject*
 Member::post_validate( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    if( get_post_validate_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom, oldvalue, newvalue );  // LCOV_EXCL_LINE
-    return handlers[ get_post_validate_mode() ]( this, atom, oldvalue, newvalue );
+    return handlers[ get_post_validate_mode() & 0x7 ]( this, atom, oldvalue, newvalue );
 }
 
 }  // namespace atom

--- a/atom/src/postvalidatebehavior.cpp
+++ b/atom/src/postvalidatebehavior.cpp
@@ -103,7 +103,7 @@ handlers[] = {
     no_op_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handlers" );
+const auto mask = validate_handlers(handlers, PostValidate::Mode::Last);
 
 }  // namespace
 
@@ -111,7 +111,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 8, "Must be exactly 8 handl
 PyObject*
 Member::post_validate( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    return handlers[ get_post_validate_mode() & 0x7 ]( this, atom, oldvalue, newvalue );
+    return handlers[ get_post_validate_mode() & mask ]( this, atom, oldvalue, newvalue );
 }
 
 }  // namespace atom

--- a/atom/src/setattrbehavior.cpp
+++ b/atom/src/setattrbehavior.cpp
@@ -383,7 +383,7 @@ handlers[] = {
     no_op_handler
 };
 
-static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
+const auto mask = validate_handlers(handlers, SetAttr::Mode::Last);
 
 } // namespace
 
@@ -391,7 +391,7 @@ static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 han
 int
 Member::setattr( CAtom* atom, PyObject* value )
 {
-    return handlers[ get_setattr_mode() & 0xf ]( this, atom, value );
+    return handlers[ get_setattr_mode() & mask ]( this, atom, value );
 }
 
 

--- a/atom/src/setattrbehavior.cpp
+++ b/atom/src/setattrbehavior.cpp
@@ -377,9 +377,13 @@ handlers[] = {
     call_object_object_name_value_handler,
     object_method_value_handler,
     object_method_name_value_handler,
-    member_method_object_value_handler
+    member_method_object_value_handler,
+    no_op_handler,
+    no_op_handler,
+    no_op_handler
 };
 
+static_assert( sizeof(handlers) / sizeof(handler) == 16, "Must be exactly 16 handlers" );
 
 } // namespace
 
@@ -387,9 +391,7 @@ handlers[] = {
 int
 Member::setattr( CAtom* atom, PyObject* value )
 {
-    if( get_setattr_mode() >= sizeof( handlers ) )
-        return no_op_handler( this, atom, value );  // LCOV_EXCL_LINE
-    return handlers[ get_setattr_mode() ]( this, atom, value );
+    return handlers[ get_setattr_mode() & 0xf ]( this, atom, value );
 }
 
 

--- a/atom/src/validatebehavior.cpp
+++ b/atom/src/validatebehavior.cpp
@@ -1007,7 +1007,7 @@ handlers[] = {
 PyObject*
 Member::validate( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    if( get_validate_mode() >= sizeof( handlers ) )
+    if( get_validate_mode() >= sizeof( handlers ) / sizeof( handler ) )
         return no_op_handler( this, atom, oldvalue, newvalue );  // LCOV_EXCL_LINE
     return handlers[ get_validate_mode() ]( this, atom, oldvalue, newvalue );
 }

--- a/atom/src/validatebehavior.cpp
+++ b/atom/src/validatebehavior.cpp
@@ -1000,6 +1000,7 @@ handlers[] = {
     member_method_object_old_new_handler
 };
 
+const auto mask = validate_handlers(handlers, Validate::Mode::Last);
 
 }  // namespace
 
@@ -1007,9 +1008,7 @@ handlers[] = {
 PyObject*
 Member::validate( CAtom* atom, PyObject* oldvalue, PyObject* newvalue )
 {
-    if( get_validate_mode() >= sizeof( handlers ) / sizeof( handler ) )
-        return no_op_handler( this, atom, oldvalue, newvalue );  // LCOV_EXCL_LINE
-    return handlers[ get_validate_mode() ]( this, atom, oldvalue, newvalue );
+    return handlers[ get_validate_mode() & mask ]( this, atom, oldvalue, newvalue );
 }
 
 


### PR DESCRIPTION
My IDE was giving a warning because the if statements were always false. 

After looking at it more it looks like it was accidentally doing a size instead of array size check.

Since all the modes except for validate behavior have less than 15 handlers I made it fill out the array with the default handler and cast the mode to a 0xf so no if statement is needed.