### PR TITLE
Use packed struct with bitfields to shrink all member modes down to 32-bits

### DIFF
--- a/atom/src/behaviors.h
+++ b/atom/src/behaviors.h
@@ -14,7 +14,7 @@ namespace atom
 namespace GetAttr
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Slot,
@@ -37,7 +37,7 @@ enum Mode
 namespace PostGetAttr
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Delegate,
@@ -53,7 +53,7 @@ enum Mode
 namespace SetAttr
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Slot,
@@ -77,7 +77,7 @@ enum Mode
 namespace PostSetAttr
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Delegate,
@@ -94,7 +94,7 @@ enum Mode
 namespace DefaultValue
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Static,
@@ -119,7 +119,7 @@ enum Mode
 namespace Validate
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Bool,
@@ -162,7 +162,7 @@ enum Mode
 namespace PostValidate
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Delegate,
@@ -178,7 +178,7 @@ enum Mode
 namespace DelAttr
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     NoOp,
     Slot,
@@ -197,7 +197,7 @@ enum Mode
 namespace GetState
 {
 
-enum Mode
+enum Mode: uint8_t
 {
     Include,  // We want include to be the default behavior
     Exclude,

--- a/atom/src/member.cpp
+++ b/atom/src/member.cpp
@@ -390,7 +390,6 @@ Member_clone( Member* self )
         return 0;
     Member* clone = member_cast( pyclone );
     clone->modes = self->modes;
-    clone->extra_modes = self->extra_modes;
     clone->index = self->index;
     clone->name = cppy::incref( self->name );
     if( self->metadata )

--- a/atom/src/member.h
+++ b/atom/src/member.h
@@ -25,6 +25,19 @@
 namespace atom
 {
 
+struct __attribute__((packed)) MemberModes
+{
+    uint8_t getattr: 4;
+    uint8_t post_getattr: 3;
+    uint8_t setattr: 4;
+    uint8_t post_setattr: 3;
+    uint8_t default_value: 4;
+    uint8_t validate: 5;
+    uint8_t post_validate: 3;
+    uint8_t delattr: 3;
+    uint8_t getstate: 3;
+};
+
 struct Member
 {
     PyObject_HEAD
@@ -41,7 +54,7 @@ struct Member
     PyObject* getstate_context;
     ModifyGuard<Member>* modify_guard;
     std::vector<Observer>* static_observers;
-    uint64_t modes;
+    MemberModes modes;
     uint32_t index;
 
     static PyType_Spec TypeObject_Spec;
@@ -56,101 +69,92 @@ struct Member
 
     GetAttr::Mode get_getattr_mode()
     {
-        return static_cast<GetAttr::Mode>( modes & 0xff );
+        return static_cast<GetAttr::Mode>( modes.getattr );
     }
 
     void set_getattr_mode( GetAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffffffffffff00 );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) );
+        modes.getattr = static_cast<uint8_t>( mode );
     }
 
     SetAttr::Mode get_setattr_mode()
     {
-        return static_cast<SetAttr::Mode>( ( modes >> 8 ) & 0xff );
+        return static_cast<SetAttr::Mode>( modes.setattr );
     }
 
     void set_setattr_mode( SetAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffffffffff00ff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 8 );
+        modes.setattr = static_cast<uint8_t>( mode );
     }
 
     PostGetAttr::Mode get_post_getattr_mode()
     {
-        return static_cast<PostGetAttr::Mode>( ( modes >> 16 ) & 0xff );
+        return static_cast<PostGetAttr::Mode>( modes.post_getattr );
     }
 
     void set_post_getattr_mode( PostGetAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffffffff00ffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 16 );
+        modes.post_getattr = static_cast<uint8_t>( mode );
     }
 
     PostSetAttr::Mode get_post_setattr_mode()
     {
-        return static_cast<PostSetAttr::Mode>( ( modes >> 24 ) & 0xff );
+        return static_cast<PostSetAttr::Mode>( modes.post_setattr );
     }
 
     void set_post_setattr_mode( PostSetAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffffff00ffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 24 );
+        modes.post_setattr = static_cast<uint8_t>( mode );
     }
 
     DefaultValue::Mode get_default_value_mode()
     {
-        return static_cast<DefaultValue::Mode>( ( modes >> 32 ) & 0xff );
+        return static_cast<DefaultValue::Mode>( modes.default_value );
     }
 
     void set_default_value_mode( DefaultValue::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffff00ffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 32 );
+        modes.default_value = static_cast<uint8_t>( mode );
     }
 
     Validate::Mode get_validate_mode()
     {
-        return static_cast<Validate::Mode>( ( modes >> 40 ) & 0xff );
+        return static_cast<Validate::Mode>( modes.validate );
     }
 
     void set_validate_mode( Validate::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffff00ffffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 40 );
+        modes.validate = static_cast<uint8_t>( mode );
     }
 
     PostValidate::Mode get_post_validate_mode()
     {
-        return static_cast<PostValidate::Mode>( ( modes >> 48 ) & 0xff );
+        return static_cast<PostValidate::Mode>( modes.post_validate );
     }
 
     void set_post_validate_mode( PostValidate::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xff00ffffffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 48 );
+        modes.post_validate = static_cast<uint8_t>( mode );
     }
 
     DelAttr::Mode get_delattr_mode()
     {
-        return static_cast<DelAttr::Mode>( ( modes >> 56 ) & 0xf );
+        return static_cast<DelAttr::Mode>( modes.delattr );
     }
 
     void set_delattr_mode( DelAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xf0ffffffffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xf ) << 56 );
+        modes.delattr = static_cast<uint8_t>( mode );
     }
 
     GetState::Mode get_getstate_mode()
     {
-        return static_cast<GetState::Mode>( ( modes >> 60 ) & 0xf );
+        return static_cast<GetState::Mode>( modes.getstate );
     }
 
     void set_getstate_mode( GetState::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0x0fffffffffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xf ) << 60 );
+        modes.getstate = static_cast<uint8_t>( mode );
     }
 
     PyObject* getattr( CAtom* atom );

--- a/atom/src/member.h
+++ b/atom/src/member.h
@@ -28,9 +28,6 @@ namespace atom
 struct Member
 {
     PyObject_HEAD
-    uint64_t modes;
-    uint64_t extra_modes;
-    uint32_t index;
     PyObject* name;
     PyObject* metadata;
     PyObject* getattr_context;
@@ -44,6 +41,8 @@ struct Member
     PyObject* getstate_context;
     ModifyGuard<Member>* modify_guard;
     std::vector<Observer>* static_observers;
+    uint64_t modes;
+    uint32_t index;
 
     static PyType_Spec TypeObject_Spec;
 
@@ -134,24 +133,24 @@ struct Member
 
     DelAttr::Mode get_delattr_mode()
     {
-        return static_cast<DelAttr::Mode>( ( modes >> 56 ) & 0xff );
+        return static_cast<DelAttr::Mode>( ( modes >> 56 ) & 0xf );
     }
 
     void set_delattr_mode( DelAttr::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0x00ffffffffffffff );
-        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) << 56 );
+        uint64_t mask = UINT64_C( 0xf0ffffffffffffff );
+        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xf ) << 56 );
     }
 
     GetState::Mode get_getstate_mode()
     {
-        return static_cast<GetState::Mode>( ( extra_modes ) & 0xff );
+        return static_cast<GetState::Mode>( ( modes >> 60 ) & 0xf );
     }
 
     void set_getstate_mode( GetState::Mode mode )
     {
-        uint64_t mask = UINT64_C( 0xffffffffffffff00 );
-        extra_modes = ( extra_modes & mask ) | ( static_cast<uint64_t>( mode & 0xff ) );
+        uint64_t mask = UINT64_C( 0x0fffffffffffffff );
+        modes = ( modes & mask ) | ( static_cast<uint64_t>( mode & 0xf ) << 60 );
     }
 
     PyObject* getattr( CAtom* atom );

--- a/atom/src/member.h
+++ b/atom/src/member.h
@@ -25,7 +25,7 @@
 namespace atom
 {
 
-struct __attribute__((packed)) MemberModes
+PACK(struct MemberModes
 {
     uint8_t getattr: 4;
     uint8_t post_getattr: 3;
@@ -36,7 +36,7 @@ struct __attribute__((packed)) MemberModes
     uint8_t post_validate: 3;
     uint8_t delattr: 3;
     uint8_t getstate: 3;
-};
+});
 
 struct Member
 {

--- a/atom/src/member.h
+++ b/atom/src/member.h
@@ -27,15 +27,15 @@ namespace atom
 
 PACK(struct MemberModes
 {
-    uint8_t getattr: 4;
-    uint8_t post_getattr: 3;
-    uint8_t setattr: 4;
-    uint8_t post_setattr: 3;
-    uint8_t default_value: 4;
-    uint8_t validate: 5;
-    uint8_t post_validate: 3;
-    uint8_t delattr: 3;
-    uint8_t getstate: 3;
+    GetAttr::Mode getattr: 4;
+    PostGetAttr::Mode post_getattr: 3;
+    SetAttr::Mode setattr: 4;
+    PostSetAttr::Mode post_setattr: 3;
+    DefaultValue::Mode default_value: 4;
+    Validate::Mode validate: 5;
+    PostValidate::Mode post_validate: 3;
+    DelAttr::Mode delattr: 3;
+    GetState::Mode getstate: 3;
 });
 
 struct Member
@@ -69,92 +69,92 @@ struct Member
 
     GetAttr::Mode get_getattr_mode()
     {
-        return static_cast<GetAttr::Mode>( modes.getattr );
+        return modes.getattr;
     }
 
     void set_getattr_mode( GetAttr::Mode mode )
     {
-        modes.getattr = static_cast<uint8_t>( mode );
+        modes.getattr = mode;
     }
 
     SetAttr::Mode get_setattr_mode()
     {
-        return static_cast<SetAttr::Mode>( modes.setattr );
+        return modes.setattr;
     }
 
     void set_setattr_mode( SetAttr::Mode mode )
     {
-        modes.setattr = static_cast<uint8_t>( mode );
+        modes.setattr = mode;
     }
 
     PostGetAttr::Mode get_post_getattr_mode()
     {
-        return static_cast<PostGetAttr::Mode>( modes.post_getattr );
+        return modes.post_getattr;
     }
 
     void set_post_getattr_mode( PostGetAttr::Mode mode )
     {
-        modes.post_getattr = static_cast<uint8_t>( mode );
+        modes.post_getattr = mode;
     }
 
     PostSetAttr::Mode get_post_setattr_mode()
     {
-        return static_cast<PostSetAttr::Mode>( modes.post_setattr );
+        return modes.post_setattr;
     }
 
     void set_post_setattr_mode( PostSetAttr::Mode mode )
     {
-        modes.post_setattr = static_cast<uint8_t>( mode );
+        modes.post_setattr = mode;
     }
 
     DefaultValue::Mode get_default_value_mode()
     {
-        return static_cast<DefaultValue::Mode>( modes.default_value );
+        return modes.default_value;
     }
 
     void set_default_value_mode( DefaultValue::Mode mode )
     {
-        modes.default_value = static_cast<uint8_t>( mode );
+        modes.default_value = mode;
     }
 
     Validate::Mode get_validate_mode()
     {
-        return static_cast<Validate::Mode>( modes.validate );
+        return modes.validate;
     }
 
     void set_validate_mode( Validate::Mode mode )
     {
-        modes.validate = static_cast<uint8_t>( mode );
+        modes.validate = mode;
     }
 
     PostValidate::Mode get_post_validate_mode()
     {
-        return static_cast<PostValidate::Mode>( modes.post_validate );
+        return modes.post_validate;
     }
 
     void set_post_validate_mode( PostValidate::Mode mode )
     {
-        modes.post_validate = static_cast<uint8_t>( mode );
+        modes.post_validate = mode;
     }
 
     DelAttr::Mode get_delattr_mode()
     {
-        return static_cast<DelAttr::Mode>( modes.delattr );
+        return modes.delattr;
     }
 
     void set_delattr_mode( DelAttr::Mode mode )
     {
-        modes.delattr = static_cast<uint8_t>( mode );
+        modes.delattr = mode;
     }
 
     GetState::Mode get_getstate_mode()
     {
-        return static_cast<GetState::Mode>( modes.getstate );
+        return modes.getstate;
     }
 
     void set_getstate_mode( GetState::Mode mode )
     {
-        modes.getstate = static_cast<uint8_t>( mode );
+        modes.getstate = mode;
     }
 
     PyObject* getattr( CAtom* atom );

--- a/atom/src/platstdint.h
+++ b/atom/src/platstdint.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #ifdef _MSC_VER
+#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
 #include "msstdint.h"
 #else
 #include <stdint.h>
+#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
 #endif


### PR DESCRIPTION
All of the modes can fit into 32 bits. This shrinks the member struct down to 128 bytes (from 144) with an alignment of 8.

The compiler also nicely does all the bit fiddling.