### PR TITLE
Return error if num args is incorrect in parse_mod_and_context

### DIFF
--- a/atom/src/member.cpp
+++ b/atom/src/member.cpp
@@ -458,7 +458,10 @@ parse_mode_and_context( PyObject*const *args, Py_ssize_t n, PyObject** context, 
 {
 
     if( n != 2 )
+    {
+        cppy::type_error( "set mode requires two arguments mode, context" );
         return false;
+    }
     if( !EnumTypes::from_py_enum( args[0], mode ) )
         return false;
     *context = args[1];

--- a/tests/test_get_behaviors.py
+++ b/tests/test_get_behaviors.py
@@ -174,3 +174,12 @@ def test_handling_wrong_index():
 
     with pytest.raises(AttributeError):
         SlotAtom.v.do_getattr(sa)
+
+
+def test_using_invalid_args():
+    """Test using the invalid arguments."""
+    v = Value()
+    with pytest.raises(TypeError):
+        v.set_getattr_mode(None)
+    with pytest.raises(TypeError):
+        v.set_getattr_mode(7, None)


### PR DESCRIPTION
While testing invalid values for #235 I found that I didn't set an error for the incorrect number of arguments when updating parse_mode_and_context. 