### PR TITLE
Avoid copying cppy::ptrs in safe_richcompare

### DIFF
--- a/atom/src/utils.h
+++ b/atom/src/utils.h
@@ -140,7 +140,7 @@ inline bool safe_richcompare( PyObject* first, const cppy::ptr &second, int opid
     return safe_richcompare( first, second.get(), opid );
 }
 
-
+// Passing by reference avoids an extra incref/decref pair
 inline bool safe_richcompare( const cppy::ptr &first, const cppy::ptr &second, int opid )
 {
     return safe_richcompare( first.get(), second.get(), opid );

--- a/atom/src/utils.h
+++ b/atom/src/utils.h
@@ -129,19 +129,19 @@ inline bool safe_richcompare( PyObject* first, PyObject* second, int opid )
     return false;
 }
 
-inline bool safe_richcompare( cppy::ptr first, PyObject* second, int opid )
+inline bool safe_richcompare( const cppy::ptr &first, PyObject* second, int opid )
 {
     return safe_richcompare( first.get(), second, opid );
 }
 
 
-inline bool safe_richcompare( PyObject* first, cppy::ptr second, int opid )
+inline bool safe_richcompare( PyObject* first, const cppy::ptr &second, int opid )
 {
     return safe_richcompare( first, second.get(), opid );
 }
 
 
-inline bool safe_richcompare( cppy::ptr first, cppy::ptr second, int opid )
+inline bool safe_richcompare( const cppy::ptr &first, const cppy::ptr &second, int opid )
 {
     return safe_richcompare( first.get(), second.get(), opid );
 }


### PR DESCRIPTION
Avoid an xincref/xdecref for each argument of each call... see https://godbolt.org/z/WPdo6fG39

Also is it necessary to mark the PyObject* version of safe_richcompare as inline?