### PR TITLE
Draft: create CAtomMeta to avoid getattr when creating Atoms

### DIFF
--- a/atom/atom.py
+++ b/atom/atom.py
@@ -38,21 +38,6 @@ class Atom(CAtom, metaclass=AtomMeta):
 
     """
 
-    __atom_members__: ClassVar[Mapping[str, Member]]
-
-    @classmethod
-    def members(cls) -> Mapping[str, Member]:
-        """Get the members dictionary for the type.
-
-        Returns
-        -------
-        result : Mapping[str, Member]
-            The dictionary of members defined on the class. User code
-            should not modify the contents of the dict.
-
-        """
-        return cls.__atom_members__
-
     @contextmanager
     def suppress_notifications(self) -> Iterator[None]:
         """Disable member notifications within in a context.

--- a/atom/meta/atom_meta.py
+++ b/atom/meta/atom_meta.py
@@ -28,6 +28,7 @@ from typing import (
 
 from ..catom import (
     CAtom,
+    CAtomMeta,
     DefaultValue,
     GetState,
     Member,
@@ -63,7 +64,7 @@ def add_member(cls: "AtomMeta", name: str, member: Member) -> None:
 
     member.set_name(name)
     # The dict is mutable but we do not want to say it too loud
-    cls.__atom_members__[name] = member  # type: ignore
+    cls.__add_member(name, member)  # type: ignore
     cls.__atom_specific_members__ = frozenset(
         set(cls.__atom_specific_members__) | {name}
     )
@@ -501,7 +502,7 @@ class _AtomMetaHelper:
         return cls
 
 
-class AtomMeta(type):
+class AtomMeta(CAtomMeta):
     """The metaclass for classes derived from Atom.
 
     This metaclass computes the memory layout of the members in a given
@@ -515,7 +516,6 @@ class AtomMeta(type):
 
     """
 
-    __atom_members__: Mapping[str, Member]
     __atom_specific_members__: FrozenSet[str]
 
     def __new__(

--- a/atom/src/catommeta.cpp
+++ b/atom/src/catommeta.cpp
@@ -1,0 +1,257 @@
+/*-----------------------------------------------------------------------------
+ | Copyright (c) 2025, Nucleic Development Team.                           *
+ |
+ | Distributed under the terms of the Modified BSD License.
+ |
+ | The full license is in the file LICENSE, distributed with this software.
+ |----------------------------------------------------------------------------*/
+#include "catommeta.h"
+#include "member.h"
+#include "packagenaming.h"
+
+namespace atom
+{
+
+namespace
+{
+
+static PyObject* atom_members_str;
+
+static PyObject* invalid_members_error()
+{
+    return cppy::system_error("CAtomMeta members are not initialized. Subclasses that use __init_subclass__ must call super().__init_subclass__()");
+}
+
+void
+CAtomMeta_clear( CAtomMeta* self )
+{
+    Py_CLEAR( self->atom_members );
+}
+
+int
+CAtomMeta_traverse( CAtomMeta* self, visitproc visit, void* arg )
+{
+    Py_VISIT( self->atom_members );
+    return 0;
+}
+
+void
+CAtomMeta_dealloc( CAtomMeta* self )
+{
+    PyObject_GC_UnTrack( self );
+    CAtomMeta_clear( self );
+    Py_TYPE(self)->tp_free( pyobject_cast( self ) );
+}
+
+PyObject*
+CAtomMeta_get_atom_members( CAtomMeta* self, void* context )
+{
+    if ( !self->atom_members )
+        return invalid_members_error();
+    return cppy::incref( self->atom_members );
+}
+
+// Validates the members argument and returns the slot count required.
+// If an error occurs it returns -1 and sets an error
+int
+CAtomMeta_validate_members( CAtomMeta* self, PyObject* members )
+{
+    if ( !PyDict_CheckExact( members ) )
+    {
+        cppy::type_error("CAtomMeta __atom_members__ must be a dict");
+        return -1;
+    }
+
+    PyObject *key, *value;
+    uint32_t count = 0;
+    Py_ssize_t pos = 0;
+    utils::CriticalSection lock( members );
+    while ( PyDict_Next( members, &pos, &key, &value ) )
+    {
+        if ( !PyUnicode_CheckExact( key ) )
+        {
+            cppy::type_error("CAtomMeta __atom_members__ key must be a str");
+            return -1;
+        }
+        if ( !Member::TypeCheck( value ) )
+        {
+            cppy::type_error("CAtomMeta __atom_members__ value must be a Member");
+            return -1;
+        }
+
+        // Members that don't require storage can set the index over the limit
+        Member* member = reinterpret_cast<Member*>( value );
+        if ( member->index < MAX_MEMBER_COUNT )
+            count += 1;
+    }
+    if (count > MAX_MEMBER_COUNT)
+    {
+        cppy::type_error("CAtomMeta __atom_members__ has too many members");
+        return -1;
+    }
+    return count;
+}
+
+int
+CAtomMeta_set_atom_members( CAtomMeta* self, PyObject* members, void* context )
+{
+    int count = CAtomMeta_validate_members( self, members );
+    if ( count < 0 )
+        return -1;
+    self->atom_members = cppy::incref( members );
+    self->slot_count = count;
+    return 0;
+}
+
+PyObject*
+CAtomMeta_init_subclass( CAtomMeta* self )
+{
+    // Since type_new does a copy of the attrs and does not use setattr
+    // we have to manually move __atom_members__ from the internal dict
+    // to the our managed self->atom_members pointer
+    if ( !self->atom_members )
+    {
+        if ( PyObject** dict = _PyObject_GetDictPtr( pyobject_cast(self) ) )
+        {
+            if ( PyObject* members = PyDict_GetItem( *dict, atom_members_str ) )
+            {
+                if ( CAtomMeta_set_atom_members( self , members, 0 ) < 0 )
+                    return 0;
+                if ( PyDict_DelItem( *dict, atom_members_str ) < 0)
+                    return 0;  // LCOV_EXCL_LINE
+            }
+        }
+
+    }
+    // If it was not set return an error
+    if ( !self->atom_members )
+        return invalid_members_error();
+    Py_RETURN_NONE;
+}
+
+// Updates the slot
+bool
+CAtomMeta_update_slot_count( CAtomMeta* self )
+{
+    if ( !self->atom_members )
+        return invalid_members_error();
+    int count = CAtomMeta_validate_members( self, self->atom_members );
+    if ( count < 0 )
+        return false;
+    self->slot_count = count;
+    return true;
+}
+
+PyObject*
+CAtomMeta_get_member( CAtomMeta* self, PyObject* name )
+{
+    if ( !PyUnicode_Check(name) )
+        return cppy::type_error("get_member name must be a str");
+    if ( !self->atom_members )
+        return invalid_members_error();
+    PyObject* member = PyDict_GetItem( self->atom_members, name );
+    if ( !member )
+        Py_RETURN_NONE;
+    return cppy::incref(member);
+}
+
+PyObject*
+CAtomMeta_set_member( CAtomMeta* self, PyObject*const *args,  Py_ssize_t n )
+{
+    if ( n != 2 || !PyUnicode_Check(args[0]) || !Member::TypeCheck(args[1]) )
+        return cppy::type_error("set_member requires 2 arguments name, member");
+    if ( !self->atom_members )
+        return invalid_members_error();
+    if ( PyDict_SetItem( self->atom_members, args[0], args[1] ) < 0 )
+        return 0;
+    if ( !CAtomMeta_update_slot_count( self ) )
+        return 0;
+    Py_RETURN_NONE;
+}
+
+PyObject*
+CAtomMeta_del_member( CAtomMeta* self, PyObject* name )
+{
+    if ( !PyUnicode_Check(name) )
+        return cppy::type_error("del_member name must be a str");
+    if ( !self->atom_members )
+        return invalid_members_error();
+    if ( PyDict_DelItem( self->atom_members, name ) < 0 )
+        return 0;
+    if ( !CAtomMeta_update_slot_count( self ) )
+        return 0;
+    Py_RETURN_NONE;
+}
+
+static PyGetSetDef
+CAtomMeta_getset[] = {
+    { "__atom_members__", ( getter )CAtomMeta_get_atom_members, ( setter )CAtomMeta_set_atom_members,
+        "Get and set the atom members." },
+    { 0 } // sentinel
+};
+
+static PyMethodDef
+CAtomMeta_methods[] = {
+
+    { "get_member", ( PyCFunction )CAtomMeta_get_member, METH_O,
+        "Get the member with the given name." },
+    { "__add_member", ( PyCFunction )CAtomMeta_set_member, METH_FASTCALL,
+        "Set the member with the given name." },
+    { "__del_member", ( PyCFunction )CAtomMeta_del_member, METH_O,
+            "Delete the member with the given name." },
+    { "members", ( PyCFunction )CAtomMeta_get_atom_members, METH_NOARGS,
+        "Get all the members." },
+    { 0 } // sentinel
+};
+
+static PyType_Slot CAtomMeta_Type_slots[] = {
+    { Py_tp_dealloc, void_cast( CAtomMeta_dealloc ) },
+    { Py_tp_traverse, void_cast( CAtomMeta_traverse ) },
+    { Py_tp_clear, void_cast( CAtomMeta_clear ) },
+    { Py_tp_methods, void_cast( CAtomMeta_methods ) },
+    { Py_tp_getset, void_cast( CAtomMeta_getset ) },
+    { Py_tp_free, void_cast( PyObject_GC_Del ) },
+    { 0, 0 },
+};
+
+} // namespace
+
+// Initialize static variables (otherwise the compiler eliminates them)
+PyTypeObject* CAtomMeta::TypeObject = NULL;
+
+PyType_Spec CAtomMeta::TypeObject_Spec = {
+    .name = PACKAGE_TYPENAME( "CAtomMeta" ),
+    .basicsize = sizeof( CAtomMeta ),
+    .itemsize = 0,
+    .flags = Py_TPFLAGS_DEFAULT |Py_TPFLAGS_BASETYPE |Py_TPFLAGS_HAVE_GC,
+    .slots = CAtomMeta_Type_slots
+};
+
+bool CAtomMeta::Ready()
+{
+    atom_members_str = PyUnicode_InternFromString( "__atom_members__" );
+    if ( !atom_members_str )
+        return 0;
+    TypeObject = pytype_cast( PyType_FromSpecWithBases( &TypeObject_Spec, pyobject_cast( &PyType_Type ) ) );
+    return TypeObject != 0;
+}
+
+PyObject*
+CAtomMeta::members( )
+{
+    return CAtomMeta_get_atom_members( this, 0 );
+}
+
+PyObject*
+CAtomMeta::get_member( PyObject* name )
+{
+    return CAtomMeta_get_member( this, name );
+}
+
+PyObject*
+CAtomMeta::init_subclass()
+{
+    return CAtomMeta_init_subclass( this );
+}
+
+} // namespace atom

--- a/atom/src/catommeta.h
+++ b/atom/src/catommeta.h
@@ -1,0 +1,42 @@
+/*-----------------------------------------------------------------------------
+ | Copyright (c) 2025, Nucleic Development Team.                           *
+ |
+ | Distributed under the terms of the Modified BSD License.
+ |
+ | The full license is in the file LICENSE, distributed with this software.
+ |----------------------------------------------------------------------------*/
+#pragma once
+
+#include <cppy/cppy.h>
+#include "platstdint.h"
+#define catommeta_cast( o ) ( reinterpret_cast<atom::CAtomMeta*>( o ) )
+
+
+namespace atom
+{
+
+// Base type for all CAtom classes
+// see cpythons's testapi/heaptype.c'
+struct CAtomMeta
+{
+    PyHeapTypeObject base;
+    PyObject* atom_members;
+    uint16_t slot_count;
+
+    static PyType_Spec TypeObject_Spec;
+    static PyTypeObject* TypeObject;
+    static bool Ready();
+    static int TypeCheck( PyObject* object )
+    {
+        return PyObject_TypeCheck( object, TypeObject );
+    }
+
+    // All of these functions may return 0 and set an error
+    // if the class was not properly initialized
+    PyObject* init_subclass();
+    PyObject* members(); // New reference.
+    PyObject* get_member( PyObject* name );
+
+};
+
+}

--- a/atom/src/catommodule.cpp
+++ b/atom/src/catommodule.cpp
@@ -8,6 +8,7 @@
 #include <cppy/cppy.h>
 #include "behaviors.h"
 #include "catom.h"
+#include "catommeta.h"
 #include "member.h"
 #include "memberchange.h"
 #include "eventbinder.h"
@@ -52,6 +53,10 @@ bool ready_types()
         return false;
     }
     if( !Member::Ready() )
+    {
+        return false;
+    }
+    if( !CAtomMeta::Ready() )
     {
         return false;
     }
@@ -129,6 +134,14 @@ bool add_objects( PyObject* mod )
 		return false;
 	}
     member.release();
+
+    // CAtomMeta
+    cppy::ptr catommeta( pyobject_cast( CAtomMeta::TypeObject ) );
+    if( PyModule_AddObject( mod, "CAtomMeta", catommeta.get() ) < 0 )
+    {
+        return false;
+    }
+    catommeta.release();
 
     // CAtom
     cppy::ptr catom( pyobject_cast( CAtom::TypeObject ) );

--- a/atom/src/utils.h
+++ b/atom/src/utils.h
@@ -16,6 +16,21 @@ namespace atom
 namespace utils
 {
 
+// Used to guard python functions that are not thread safe in the free-threaded build
+struct CriticalSection
+{
+    CriticalSection(PyObject* obj) {
+#if defined(Py_GIL_DISABLED)
+        Py_BEGIN_CRITICAL_SECTION(obj);
+#endif
+    }
+    ~CriticalSection() {
+#if defined(Py_GIL_DISABLED)
+        Py_END_CRITICAL_SECTION();
+#endif
+    }
+};
+
 inline PyObject*
 py_bool( bool val )
 {

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ ext_modules = [
             "atom/src/atomset.cpp",
             "atom/src/atomref.cpp",
             "atom/src/catom.cpp",
+            "atom/src/catommeta.cpp",
             "atom/src/catommodule.cpp",
             "atom/src/defaultvaluebehavior.cpp",
             "atom/src/delattrbehavior.cpp",

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -350,9 +350,23 @@ def test_init_subclass():
     assert members == {"a": B.a}
 
 
+def test_subclass_init_missing():
+    with pytest.raises(SystemError):
+
+        class A(Atom):
+            def __init_subclass__(cls) -> None:
+                # This is called when subclassing B
+                # Must call super or __atom_members__ is not there
+                cls.members()
+
+        class B(A):
+            pass
+
+
 def test_clone_if_needed():
     class A(Atom):
         def __init_subclass__(cls) -> None:
+            super().__init_subclass__()
             for m in cls.members().values():
                 clone_if_needed(cls, m)
 


### PR DESCRIPTION
Currently CAtom_new relies on the metaclass to set `__atom_members__` on the type and must use getattr on the type read the size in order to set the slot count.

This adds a `CAtomMeta` that subclasses the builtin `PyType_Type` and updates the existing AtomMeta to use that. 

This means it can simply do a TypeCheck and then access the slot_count on the type. I see a repeatable speedup of several percent when creating atom objects.  

With current master
```python
IPython 8.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from atom.api import *

In [2]: class Test(Atom):
   ...:     first_name = Str("First")
   ...:     last_name = Str("Last")
   ...:     age = Range(low=0)
   ...:     debug = Bool(False)
   ...:     items = List(default=[1, 2, 3])
   ...: 

In [3]: %timeit Test()
118 ns ± 9.84 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit Test()
129 ns ± 10.5 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %timeit Test()
122 ns ± 7.26 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]: %timeit Test()
127 ns ± 8.6 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

```

With this branch (and logic to avoid the second write in #243)
```py
IPython 8.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from atom.api import *

In [2]: class Test(Atom):
   ...:     first_name = Str("First")
   ...:     last_name = Str("Last")
   ...:     age = Range(low=0)
   ...:     debug = Bool(False)
   ...:     items = List(default=[1, 2, 3])
   ...: 

In [3]: %timeit Test()
95.6 ns ± 5.43 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [4]: %timeit Test()
104 ns ± 6.38 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [5]: %timeit Test()
105 ns ± 7.8 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [6]: %timeit Test()
106 ns ± 7.71 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```


However unfortunately I actually see a slight slowdown in my real application.. which has me confused. Is enaml creating subclasses at runtime?