### PR TITLE
ci: add Ubuntu 24.04 arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -72,7 +72,7 @@ jobs:
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ runner.os }}
+          name: cibw-wheels-${{ matrix.os }}
           path: dist/*.whl
 
   publish:


### PR DESCRIPTION
This adds `linux-aarch64` wheels to PyPI.

I've created a pipeline without the publishing to PyPI step that you can check out: https://github.com/nelsyeung/atom/actions/runs/23434135133 and here are the wheels built: https://github.com/nelsyeung/atom/releases/tag/0.12.1