### PR TITLE
Add test for cached property error case

### DIFF
--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -178,7 +178,8 @@ def test_cached_property_error():
     with pytest.raises(ValueError) as excinfo:
         o.x  # This puts null in the slot
     assert "get_x failed" in excinfo.exconly()
-    assert o.x == v
+    assert o.x == 2
+    assert o.x == 2
 
 
 def test_observed_property():

--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -160,6 +160,27 @@ def test_enforce_read_only_cached_property():
         p.setter(set)
 
 
+def test_cached_property_error():
+    """Test using a cached property that returns an error."""
+    v = 0
+
+    class Obj(Atom):
+        def _get_x(self):
+            nonlocal v
+            v += 1
+            if v & 1:
+                raise ValueError("get_x failed!")
+            return v
+
+        x = Property(_get_x, cached=True)
+
+    o = Obj()
+    with pytest.raises(ValueError) as excinfo:
+        o.x  # This puts null in the slot
+    assert "get_x failed" in excinfo.exconly()
+    assert o.x == v
+
+
 def test_observed_property():
     """Test observing a property."""
 


### PR DESCRIPTION
The code review claimed there was an issue with the getattr cached_property_handler but I see no problems. This adds test coverage for the error case.